### PR TITLE
fix: www discovery link

### DIFF
--- a/src/v1beta1/doc/google/cloud/asset/v1beta1/doc_assets.js
+++ b/src/v1beta1/doc/google/cloud/asset/v1beta1/doc_assets.js
@@ -102,7 +102,7 @@ const Asset = {
  * @property {string} discoveryDocumentUri
  *   The URL of the discovery document containing the resource's JSON schema.
  *   For example:
- *   `"https://www.googleapis.com/discovery/v1/apis/compute/v1/rest"`.
+ *   [`"https://www.googleapis.com/discovery/v1/apis/compute/v1/rest"`](https://www.googleapis.com/discovery/v1/apis/compute/v1/rest).
  *   It will be left unspecified for resources without a discovery-based API,
  *   such as Cloud Bigtable.
  *

--- a/synth.py
+++ b/synth.py
@@ -34,6 +34,11 @@ templates = common_templates.node_library()
 s.copy(templates)
 
 # [START fix-dead-link]
+discovery_url = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
+s.replace('**/doc/google/protobuf/doc_assets.js',
+        f'`"{discovery_url}"`'
+        f'[`"{discovery_url}"`]({discovery_url})')
+
 s.replace('**/doc/google/protobuf/doc_timestamp.js',
         'https:\/\/cloud\.google\.com[\s\*]*http:\/\/(.*)[\s\*]*\)',
         r"https://\1)")

--- a/synth.py
+++ b/synth.py
@@ -35,7 +35,7 @@ s.copy(templates)
 
 # [START fix-dead-link]
 discovery_url = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
-s.replace('**/doc/google/protobuf/doc_assets.js',
+s.replace('**/doc/google/cloud/asset/v1beta1/doc_assets.js',
         f'`"{discovery_url}"`'
         f'[`"{discovery_url}"`]({discovery_url})')
 


### PR DESCRIPTION
Looks like we're getting hit by https://github.com/jsdoc3/jsdoc/issues/1509 which is causing an invalid link. Forgive me if my Python is terribad!