### PR TITLE
build: add GitHub action for triggering deployments

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,12 @@
+workflow "Candidate Issue" {
+  on = "schedule(*/5 * * * *)"
+  resolves = ["candidate-issue"]
+}
+
+action "candidate-issue" {
+  uses = "googleapis/release-please/.github/action/candidate-issue@master"
+  env = {
+    PACKAGE_NAME = "@google-cloud/asset"
+  }
+  secrets = ["GITHUB_TOKEN"]
+}


### PR DESCRIPTION
adds a workflow, which will hopefully be all we need to do to enable actions on this repository.