### PR TITLE
feat!: drop node8 support, support for async iterators

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,5 @@
 {
-  "updateTime": "2020-03-31T10:43:55.667140Z",
+  "updateTime": "2020-03-31T19:12:15.219888Z",
   "destinations": [
     {
       "client": {


### PR DESCRIPTION
BREAKING CHANGE: The library now supports Node.js v10+. The last version to support Node.js v8 is tagged legacy-8 on NPM.

New feature: methods with pagination now support async iteration.