### PR TITLE
feat: add org policy and access context manager protos

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "docs": "jsdoc -c .jsdoc.js",
     "docs-test": "linkinator docs",
     "fix": "gts fix",
-    "lint": "gts check",
+    "lint": "gts fix && eslint --fix samples/*.js",
     "predocs-test": "npm run docs",
     "prepare": "npm run compile",
     "system-test": "c8 mocha build/system-test",

--- a/protos/google/cloud/asset/v1/asset_service.proto
+++ b/protos/google/cloud/asset/v1/asset_service.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
@@ -26,6 +25,7 @@ import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
+import "google/type/expr.proto";
 
 option csharp_namespace = "Google.Cloud.Asset.V1";
 option go_package = "google.golang.org/genproto/googleapis/cloud/asset/v1;asset";
@@ -125,10 +125,10 @@ message ExportAssetsRequest {
   ];
 
   // Timestamp to take an asset snapshot. This can only be set to a timestamp
-  // between 2018-10-02 UTC (inclusive) and the current time. If not specified,
-  // the current time will be used. Due to delays in resource data collection
-  // and indexing, there is a volatile window during which running the same
-  // query may get different results.
+  // between the current time and the current time minus 35 days (inclusive).
+  // If not specified, the current time will be used. Due to delays in resource
+  // data collection and indexing, there is a volatile window during which
+  // running the same query may get different results.
   google.protobuf.Timestamp read_time = 2;
 
   // A list of asset types of which to take a snapshot for. For example:
@@ -187,11 +187,11 @@ message BatchGetAssetsHistoryRequest {
   ContentType content_type = 3 [(google.api.field_behavior) = OPTIONAL];
 
   // Optional. The time window for the asset history. Both start_time and
-  // end_time are optional and if set, it must be after 2018-10-02 UTC. If
-  // end_time is not set, it is default to current timestamp. If start_time is
-  // not set, the snapshot of the assets at end_time will be returned. The
-  // returned results contain all temporal assets whose time window overlap with
-  // read_time_window.
+  // end_time are optional and if set, it must be after the current time minus
+  // 35 days. If end_time is not set, it is default to current timestamp.
+  // If start_time is not set, the snapshot of the assets at end_time will be
+  // returned. The returned results contain all temporal assets whose time
+  // window overlap with read_time_window.
   TimeWindow read_time_window = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
@@ -321,7 +321,7 @@ message BigQueryDestination {
   // Required. The BigQuery dataset in format
   // "projects/projectId/datasets/datasetId", to which the snapshot result
   // should be exported. If this dataset does not exist, the export call returns
-  // an error.
+  // an INVALID_ARGUMENT error.
   string dataset = 1 [(google.api.field_behavior) = REQUIRED];
 
   // Required. The BigQuery table to which the snapshot result should be
@@ -331,41 +331,23 @@ message BigQueryDestination {
 
   // If the destination table already exists and this flag is `TRUE`, the
   // table will be overwritten by the contents of assets snapshot. If the flag
-  // is not set and the destination table already exists, the export call
-  // returns an error.
+  // is `FALSE` or unset and the destination table already exists, the export
+  // call returns an INVALID_ARGUMEMT error.
   bool force = 3;
 }
 
-// A Cloud Pubsub destination.
+// A Pub/Sub destination.
 message PubsubDestination {
-  // The name of the Cloud Pub/Sub topic to publish to.
+  // The name of the Pub/Sub topic to publish to.
   // For example: `projects/PROJECT_ID/topics/TOPIC_ID`.
   string topic = 1;
-}
-
-// Asset content type.
-enum ContentType {
-  // Unspecified content type.
-  CONTENT_TYPE_UNSPECIFIED = 0;
-
-  // Resource metadata.
-  RESOURCE = 1;
-
-  // The actual IAM policy set on a resource.
-  IAM_POLICY = 2;
-
-  // The Cloud Organization Policy set on an asset.
-  ORG_POLICY = 4;
-
-  // The Cloud Access context mananger Policy set on an asset.
-  ACCESS_POLICY = 5;
 }
 
 // Output configuration for asset feed destination.
 message FeedOutputConfig {
   // Asset feed destination.
   oneof destination {
-    // Destination on Cloud Pubsub.
+    // Destination on Pub/Sub.
     PubsubDestination pubsub_destination = 1;
   }
 }
@@ -374,7 +356,7 @@ message FeedOutputConfig {
 // An asset feed filter controls what updates are exported.
 // The asset feed must be created within a project, organization, or
 // folder. Supported destinations are:
-// Cloud Pub/Sub topics.
+// Pub/Sub topics.
 message Feed {
   option (google.api.resource) = {
     type: "cloudasset.googleapis.com/Feed"
@@ -406,10 +388,11 @@ message Feed {
   // A list of types of the assets to receive updates. You must specify either
   // or both of asset_names and asset_types. Only asset updates matching
   // specified asset_names and asset_types are exported to the feed.
-  // For example:
-  // "compute.googleapis.com/Disk" See [Introduction to Cloud Asset
-  // Inventory](https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview)
-  // for all supported asset types.
+  // For example: `"compute.googleapis.com/Disk"`
+  //
+  // See [this
+  // topic](https://cloud.google.com/asset-inventory/docs/supported-asset-types)
+  // for a list of all supported asset types.
   repeated string asset_types = 3;
 
   // Asset content type. If not specified, no content but the asset name and
@@ -419,4 +402,22 @@ message Feed {
   // Required. Feed output configuration defining where the asset updates are
   // published to.
   FeedOutputConfig feed_output_config = 5 [(google.api.field_behavior) = REQUIRED];
+}
+
+// Asset content type.
+enum ContentType {
+  // Unspecified content type.
+  CONTENT_TYPE_UNSPECIFIED = 0;
+
+  // Resource metadata.
+  RESOURCE = 1;
+
+  // The actual IAM policy set on a resource.
+  IAM_POLICY = 2;
+
+  // The Cloud Organization Policy set on an asset.
+  ORG_POLICY = 4;
+
+  // The Cloud Access context mananger Policy set on an asset.
+  ACCESS_POLICY = 5;
 }

--- a/protos/google/cloud/asset/v1/assets.proto
+++ b/protos/google/cloud/asset/v1/assets.proto
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC.
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,14 +11,17 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 syntax = "proto3";
 
 package google.cloud.asset.v1;
 
 import "google/api/resource.proto";
+import "google/cloud/orgpolicy/v1/orgpolicy.proto";
 import "google/iam/v1/policy.proto";
+import "google/identity/accesscontextmanager/v1/access_level.proto";
+import "google/identity/accesscontextmanager/v1/access_policy.proto";
+import "google/identity/accesscontextmanager/v1/service_perimeter.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
@@ -32,31 +35,34 @@ option java_outer_classname = "AssetProto";
 option java_package = "com.google.cloud.asset.v1";
 option php_namespace = "Google\\Cloud\\Asset\\V1";
 
-// Temporal asset. In addition to the asset, the temporal asset includes the
-// status of the asset and valid from and to time of it.
+// An asset in Google Cloud and its temporal metadata, including the time window
+// when it was observed and its status during that window.
 message TemporalAsset {
   // The time window when the asset data and state was observed.
   TimeWindow window = 1;
 
-  // If the asset is deleted or not.
+  // Whether the asset has been deleted or not.
   bool deleted = 2;
 
-  // Asset.
+  // An asset in Google Cloud.
   Asset asset = 3;
 }
 
-// A time window of (start_time, end_time].
+// A time window specified by its "start_time" and "end_time".
 message TimeWindow {
   // Start time of the time window (exclusive).
   google.protobuf.Timestamp start_time = 1;
 
-  // End time of the time window (inclusive).
-  // Current timestamp if not specified.
+  // End time of the time window (inclusive). If not specified, the current
+  // timestamp is used instead.
   google.protobuf.Timestamp end_time = 2;
 }
 
-// Cloud asset. This includes all Google Cloud Platform resources,
-// Cloud IAM policies, and other non-GCP assets.
+// An asset in Google Cloud. An asset can be any resource in the Google Cloud
+// [resource
+// hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy),
+// a resource outside the Google Cloud resource hierarchy (such as Google
+// Kubernetes Engine clusters and objects), or a Cloud IAM policy.
 message Asset {
   option (google.api.resource) = {
     type: "cloudasset.googleapis.com/Asset"
@@ -64,53 +70,86 @@ message Asset {
   };
 
   // The full name of the asset. For example:
-  // `//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1`.
+  // "//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1"
+  //
   // See [Resource
-  // Names](https://cloud.google.com/apis/design/resource_names#full_resource_name)
+  // names](https://cloud.google.com/apis/design/resource_names#full_resource_name)
   // for more information.
   string name = 1;
 
-  // Type of the asset. Example: "compute.googleapis.com/Disk".
+  // The type of the asset. For example: "compute.googleapis.com/Disk"
+  //
+  // See [Supported asset
+  // types](https://cloud.google.com/asset-inventory/docs/supported-asset-types)
+  // for more information.
   string asset_type = 2;
 
-  // Representation of the resource.
+  // A representation of the resource.
   Resource resource = 3;
 
-  // Representation of the actual Cloud IAM policy set on a cloud resource. For
-  // each resource, there must be at most one Cloud IAM policy set on it.
+  // A representation of the Cloud IAM policy set on a Google Cloud resource.
+  // There can be a maximum of one Cloud IAM policy set on any given resource.
+  // In addition, Cloud IAM policies inherit their granted access scope from any
+  // policies set on parent resources in the resource hierarchy. Therefore, the
+  // effectively policy is the union of both the policy set on this resource
+  // and each policy set on all of the resource's ancestry resource levels in
+  // the hierarchy. See
+  // [this topic](https://cloud.google.com/iam/docs/policies#inheritance) for
+  // more information.
   google.iam.v1.Policy iam_policy = 4;
 
-  // Asset's ancestry path in Cloud Resource Manager (CRM) hierarchy,
-  // represented as a list of relative resource names. Ancestry path starts with
-  // the closest CRM ancestor and ends at root. If the asset is a CRM
-  // project/folder/organization, this starts from the asset itself.
+  // A representation of an [organization
+  // policy](https://cloud.google.com/resource-manager/docs/organization-policy/overview#organization_policy).
+  // There can be more than one organization policy with different constraints
+  // set on a given resource.
+  repeated google.cloud.orgpolicy.v1.Policy org_policy = 6;
+
+  // A representation of an [access
+  // policy](https://cloud.google.com/access-context-manager/docs/overview#access-policies).
+  oneof access_context_policy {
+    google.identity.accesscontextmanager.v1.AccessPolicy access_policy = 7;
+
+    google.identity.accesscontextmanager.v1.AccessLevel access_level = 8;
+
+    google.identity.accesscontextmanager.v1.ServicePerimeter service_perimeter = 9;
+  }
+
+  // The ancestry path of an asset in Google Cloud [resource
+  // hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy),
+  // represented as a list of relative resource names. An ancestry path starts
+  // with the closest ancestor in the hierarchy and ends at root. If the asset
+  // is a project, folder, or organization, the ancestry path starts from the
+  // asset itself.
   //
-  // Example: ["projects/123456789", "folders/5432", "organizations/1234"]
+  // For example: `["projects/123456789", "folders/5432", "organizations/1234"]`
   repeated string ancestors = 10;
 }
 
-// Representation of a cloud resource.
+// A representation of a Google Cloud resource.
 message Resource {
-  // The API version. Example: "v1".
+  // The API version. For example: "v1"
   string version = 1;
 
   // The URL of the discovery document containing the resource's JSON schema.
   // For example:
-  // `"https://www.googleapis.com/discovery/v1/apis/compute/v1/rest"`.
-  // It will be left unspecified for resources without a discovery-based API,
-  // such as Cloud Bigtable.
+  // "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest"
+  //
+  // This value is unspecified for resources that do not have an API based on a
+  // discovery document, such as Cloud Bigtable.
   string discovery_document_uri = 2;
 
-  // The JSON schema name listed in the discovery document.
-  // Example: "Project". It will be left unspecified for resources (such as
-  // Cloud Bigtable) without a discovery-based API.
+  // The JSON schema name listed in the discovery document. For example:
+  // "Project"
+  //
+  // This value is unspecified for resources that do not have an API based on a
+  // discovery document, such as Cloud Bigtable.
   string discovery_name = 3;
 
-  // The REST URL for accessing the resource. An HTTP GET operation using this
-  // URL returns the resource itself.
-  // Example:
-  // `https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123`.
-  // It will be left unspecified for resources without a REST API.
+  // The REST URL for accessing the resource. An HTTP `GET` request using this
+  // URL returns the resource itself. For example:
+  // "https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123"
+  //
+  // This value is unspecified for resources without a REST API.
   string resource_url = 4;
 
   // The full name of the immediate parent of this resource. See
@@ -118,15 +157,16 @@ message Resource {
   // Names](https://cloud.google.com/apis/design/resource_names#full_resource_name)
   // for more information.
   //
-  // For GCP assets, it is the parent resource defined in the [Cloud IAM policy
+  // For Google Cloud assets, this value is the parent resource defined in the
+  // [Cloud IAM policy
   // hierarchy](https://cloud.google.com/iam/docs/overview#policy_hierarchy).
   // For example:
-  // `"//cloudresourcemanager.googleapis.com/projects/my_project_123"`.
+  // "//cloudresourcemanager.googleapis.com/projects/my_project_123"
   //
-  // For third-party assets, it is up to the users to define.
+  // For third-party assets, this field may be set differently.
   string parent = 5;
 
-  // The content of the resource, in which some sensitive fields are scrubbed
-  // away and may not be present.
+  // The content of the resource, in which some sensitive fields are removed
+  // and may not be present.
   google.protobuf.Struct data = 6;
 }

--- a/protos/google/cloud/orgpolicy/v1/orgpolicy.proto
+++ b/protos/google/cloud/orgpolicy/v1/orgpolicy.proto
@@ -1,0 +1,315 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+syntax = "proto3";
+
+package google.cloud.orgpolicy.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Cloud.OrgPolicy.V1";
+option go_package = "google.golang.org/genproto/googleapis/cloud/orgpolicy/v1;orgpolicy";
+option java_multiple_files = true;
+option java_outer_classname = "OrgPolicyProto";
+option java_package = "com.google.cloud.orgpolicy.v1";
+option php_namespace = "Google\\Cloud\\OrgPolicy\\V1";
+option ruby_package = "Google::Cloud::OrgPolicy::V1";
+
+// Defines a Cloud Organization `Policy` which is used to specify `Constraints`
+// for configurations of Cloud Platform resources.
+message Policy {
+  // Used in `policy_type` to specify how `list_policy` behaves at this
+  // resource.
+  //
+  // `ListPolicy` can define specific values and subtrees of Cloud Resource
+  // Manager resource hierarchy (`Organizations`, `Folders`, `Projects`) that
+  // are allowed or denied by setting the `allowed_values` and `denied_values`
+  // fields. This is achieved by using the `under:` and optional `is:` prefixes.
+  // The `under:` prefix is used to denote resource subtree values.
+  // The `is:` prefix is used to denote specific values, and is required only
+  // if the value contains a ":". Values prefixed with "is:" are treated the
+  // same as values with no prefix.
+  // Ancestry subtrees must be in one of the following formats:
+  //     - "projects/<project-id>", e.g. "projects/tokyo-rain-123"
+  //     - "folders/<folder-id>", e.g. "folders/1234"
+  //     - "organizations/<organization-id>", e.g. "organizations/1234"
+  // The `supports_under` field of the associated `Constraint`  defines whether
+  // ancestry prefixes can be used. You can set `allowed_values` and
+  // `denied_values` in the same `Policy` if `all_values` is
+  // `ALL_VALUES_UNSPECIFIED`. `ALLOW` or `DENY` are used to allow or deny all
+  // values. If `all_values` is set to either `ALLOW` or `DENY`,
+  // `allowed_values` and `denied_values` must be unset.
+  message ListPolicy {
+    // This enum can be used to set `Policies` that apply to all possible
+    // configuration values rather than specific values in `allowed_values` or
+    // `denied_values`.
+    //
+    // Settting this to `ALLOW` will mean this `Policy` allows all values.
+    // Similarly, setting it to `DENY` will mean no values are allowed. If
+    // set to either `ALLOW` or `DENY,  `allowed_values` and `denied_values`
+    // must be unset. Setting this to `ALL_VALUES_UNSPECIFIED` allows for
+    // setting `allowed_values` and `denied_values`.
+    enum AllValues {
+      // Indicates that allowed_values or denied_values must be set.
+      ALL_VALUES_UNSPECIFIED = 0;
+
+      // A policy with this set allows all values.
+      ALLOW = 1;
+
+      // A policy with this set denies all values.
+      DENY = 2;
+    }
+
+    // List of values allowed  at this resource. Can only be set if `all_values`
+    // is set to `ALL_VALUES_UNSPECIFIED`.
+    repeated string allowed_values = 1;
+
+    // List of values denied at this resource. Can only be set if `all_values`
+    // is set to `ALL_VALUES_UNSPECIFIED`.
+    repeated string denied_values = 2;
+
+    // The policy all_values state.
+    AllValues all_values = 3;
+
+    // Optional. The Google Cloud Console will try to default to a configuration
+    // that matches the value specified in this `Policy`. If `suggested_value`
+    // is not set, it will inherit the value specified higher in the hierarchy,
+    // unless `inherit_from_parent` is `false`.
+    string suggested_value = 4;
+
+    // Determines the inheritance behavior for this `Policy`.
+    //
+    // By default, a `ListPolicy` set at a resource supercedes any `Policy` set
+    // anywhere up the resource hierarchy. However, if `inherit_from_parent` is
+    // set to `true`, then the values from the effective `Policy` of the parent
+    // resource are inherited, meaning the values set in this `Policy` are
+    // added to the values inherited up the hierarchy.
+    //
+    // Setting `Policy` hierarchies that inherit both allowed values and denied
+    // values isn't recommended in most circumstances to keep the configuration
+    // simple and understandable. However, it is possible to set a `Policy` with
+    // `allowed_values` set that inherits a `Policy` with `denied_values` set.
+    // In this case, the values that are allowed must be in `allowed_values` and
+    // not present in `denied_values`.
+    //
+    // For example, suppose you have a `Constraint`
+    // `constraints/serviceuser.services`, which has a `constraint_type` of
+    // `list_constraint`, and with `constraint_default` set to `ALLOW`.
+    // Suppose that at the Organization level, a `Policy` is applied that
+    // restricts the allowed API activations to {`E1`, `E2`}. Then, if a
+    // `Policy` is applied to a project below the Organization that has
+    // `inherit_from_parent` set to `false` and field all_values set to DENY,
+    // then an attempt to activate any API will be denied.
+    //
+    // The following examples demonstrate different possible layerings for
+    // `projects/bar` parented by `organizations/foo`:
+    //
+    // Example 1 (no inherited values):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values:"E2"}
+    //   `projects/bar` has `inherit_from_parent` `false` and values:
+    //     {allowed_values: "E3" allowed_values: "E4"}
+    // The accepted values at `organizations/foo` are `E1`, `E2`.
+    // The accepted values at `projects/bar` are `E3`, and `E4`.
+    //
+    // Example 2 (inherited values):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values:"E2"}
+    //   `projects/bar` has a `Policy` with values:
+    //     {value: "E3" value: "E4" inherit_from_parent: true}
+    // The accepted values at `organizations/foo` are `E1`, `E2`.
+    // The accepted values at `projects/bar` are `E1`, `E2`, `E3`, and `E4`.
+    //
+    // Example 3 (inheriting both allowed and denied values):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values: "E2"}
+    //   `projects/bar` has a `Policy` with:
+    //     {denied_values: "E1"}
+    // The accepted values at `organizations/foo` are `E1`, `E2`.
+    // The value accepted at `projects/bar` is `E2`.
+    //
+    // Example 4 (RestoreDefault):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values:"E2"}
+    //   `projects/bar` has a `Policy` with values:
+    //     {RestoreDefault: {}}
+    // The accepted values at `organizations/foo` are `E1`, `E2`.
+    // The accepted values at `projects/bar` are either all or none depending on
+    // the value of `constraint_default` (if `ALLOW`, all; if
+    // `DENY`, none).
+    //
+    // Example 5 (no policy inherits parent policy):
+    //   `organizations/foo` has no `Policy` set.
+    //   `projects/bar` has no `Policy` set.
+    // The accepted values at both levels are either all or none depending on
+    // the value of `constraint_default` (if `ALLOW`, all; if
+    // `DENY`, none).
+    //
+    // Example 6 (ListConstraint allowing all):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values: "E2"}
+    //   `projects/bar` has a `Policy` with:
+    //     {all: ALLOW}
+    // The accepted values at `organizations/foo` are `E1`, E2`.
+    // Any value is accepted at `projects/bar`.
+    //
+    // Example 7 (ListConstraint allowing none):
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "E1" allowed_values: "E2"}
+    //   `projects/bar` has a `Policy` with:
+    //     {all: DENY}
+    // The accepted values at `organizations/foo` are `E1`, E2`.
+    // No value is accepted at `projects/bar`.
+    //
+    // Example 10 (allowed and denied subtrees of Resource Manager hierarchy):
+    // Given the following resource hierarchy
+    //   O1->{F1, F2}; F1->{P1}; F2->{P2, P3},
+    //   `organizations/foo` has a `Policy` with values:
+    //     {allowed_values: "under:organizations/O1"}
+    //   `projects/bar` has a `Policy` with:
+    //     {allowed_values: "under:projects/P3"}
+    //     {denied_values: "under:folders/F2"}
+    // The accepted values at `organizations/foo` are `organizations/O1`,
+    //   `folders/F1`, `folders/F2`, `projects/P1`, `projects/P2`,
+    //   `projects/P3`.
+    // The accepted values at `projects/bar` are `organizations/O1`,
+    //   `folders/F1`, `projects/P1`.
+    bool inherit_from_parent = 5;
+  }
+
+  // Used in `policy_type` to specify how `boolean_policy` will behave at this
+  // resource.
+  message BooleanPolicy {
+    // If `true`, then the `Policy` is enforced. If `false`, then any
+    // configuration is acceptable.
+    //
+    // Suppose you have a `Constraint`
+    // `constraints/compute.disableSerialPortAccess` with `constraint_default`
+    // set to `ALLOW`. A `Policy` for that `Constraint` exhibits the following
+    // behavior:
+    //   - If the `Policy` at this resource has enforced set to `false`, serial
+    //     port connection attempts will be allowed.
+    //   - If the `Policy` at this resource has enforced set to `true`, serial
+    //     port connection attempts will be refused.
+    //   - If the `Policy` at this resource is `RestoreDefault`, serial port
+    //     connection attempts will be allowed.
+    //   - If no `Policy` is set at this resource or anywhere higher in the
+    //     resource hierarchy, serial port connection attempts will be allowed.
+    //   - If no `Policy` is set at this resource, but one exists higher in the
+    //     resource hierarchy, the behavior is as if the`Policy` were set at
+    //     this resource.
+    //
+    // The following examples demonstrate the different possible layerings:
+    //
+    // Example 1 (nearest `Constraint` wins):
+    //   `organizations/foo` has a `Policy` with:
+    //     {enforced: false}
+    //   `projects/bar` has no `Policy` set.
+    // The constraint at `projects/bar` and `organizations/foo` will not be
+    // enforced.
+    //
+    // Example 2 (enforcement gets replaced):
+    //   `organizations/foo` has a `Policy` with:
+    //     {enforced: false}
+    //   `projects/bar` has a `Policy` with:
+    //     {enforced: true}
+    // The constraint at `organizations/foo` is not enforced.
+    // The constraint at `projects/bar` is enforced.
+    //
+    // Example 3 (RestoreDefault):
+    //   `organizations/foo` has a `Policy` with:
+    //     {enforced: true}
+    //   `projects/bar` has a `Policy` with:
+    //     {RestoreDefault: {}}
+    // The constraint at `organizations/foo` is enforced.
+    // The constraint at `projects/bar` is not enforced, because
+    // `constraint_default` for the `Constraint` is `ALLOW`.
+    bool enforced = 1;
+  }
+
+  // Ignores policies set above this resource and restores the
+  // `constraint_default` enforcement behavior of the specific `Constraint` at
+  // this resource.
+  //
+  // Suppose that `constraint_default` is set to `ALLOW` for the
+  // `Constraint` `constraints/serviceuser.services`. Suppose that organization
+  // foo.com sets a `Policy` at their Organization resource node that restricts
+  // the allowed service activations to deny all service activations. They
+  // could then set a `Policy` with the `policy_type` `restore_default` on
+  // several experimental projects, restoring the `constraint_default`
+  // enforcement of the `Constraint` for only those projects, allowing those
+  // projects to have all services activated.
+  message RestoreDefault {
+
+  }
+
+  // Version of the `Policy`. Default version is 0;
+  int32 version = 1;
+
+  // The name of the `Constraint` the `Policy` is configuring, for example,
+  // `constraints/serviceuser.services`.
+  //
+  // Immutable after creation.
+  string constraint = 2;
+
+  // An opaque tag indicating the current version of the `Policy`, used for
+  // concurrency control.
+  //
+  // When the `Policy` is returned from either a `GetPolicy` or a
+  // `ListOrgPolicy` request, this `etag` indicates the version of the current
+  // `Policy` to use when executing a read-modify-write loop.
+  //
+  // When the `Policy` is returned from a `GetEffectivePolicy` request, the
+  // `etag` will be unset.
+  //
+  // When the `Policy` is used in a `SetOrgPolicy` method, use the `etag` value
+  // that was returned from a `GetOrgPolicy` request as part of a
+  // read-modify-write loop for concurrency control. Not setting the `etag`in a
+  // `SetOrgPolicy` request will result in an unconditional write of the
+  // `Policy`.
+  bytes etag = 3;
+
+  // The time stamp the `Policy` was previously updated. This is set by the
+  // server, not specified by the caller, and represents the last time a call to
+  // `SetOrgPolicy` was made for that `Policy`. Any value set by the client will
+  // be ignored.
+  google.protobuf.Timestamp update_time = 4;
+
+  // The field to populate is based on the `constraint_type` value in the
+  // `Constraint`.
+  //   `list_constraint` => `list_policy`
+  //   `boolean_constraint` => `boolean_policy`
+  //
+  //  A `restore_default` message may be used with any `Constraint` type.
+  //
+  // Providing a *_policy that is incompatible with the `constraint_type` will
+  // result in an `invalid_argument` error.
+  //
+  // Attempting to set a `Policy` with a `policy_type` not set will result in an
+  // `invalid_argument` error.
+  oneof policy_type {
+    // List of values either allowed or disallowed.
+    ListPolicy list_policy = 5;
+
+    // For boolean `Constraints`, whether to enforce the `Constraint` or not.
+    BooleanPolicy boolean_policy = 6;
+
+    // Restores the default behavior of the constraint; independent of
+    // `Constraint` type.
+    RestoreDefault restore_default = 7;
+  }
+}

--- a/protos/google/identity/accesscontextmanager/type/device_resources.proto
+++ b/protos/google/identity/accesscontextmanager/type/device_resources.proto
@@ -1,0 +1,85 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.identity.accesscontextmanager.type;
+
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Identity.AccessContextManager.Type";
+option go_package = "google.golang.org/genproto/googleapis/identity/accesscontextmanager/type;type";
+option java_package = "com.google.identity.accesscontextmanager.type";
+option java_multiple_files = true;
+option java_outer_classname = "TypeProto";
+option php_namespace = "Google\\Identity\\AccessContextManager\\Type";
+option ruby_package = "Google::Identity::AccessContextManager::Type";
+
+// The encryption state of the device.
+enum DeviceEncryptionStatus {
+  // The encryption status of the device is not specified or not known.
+  ENCRYPTION_UNSPECIFIED = 0;
+
+  // The device does not support encryption.
+  ENCRYPTION_UNSUPPORTED = 1;
+
+  // The device supports encryption, but is currently unencrypted.
+  UNENCRYPTED = 2;
+
+  // The device is encrypted.
+  ENCRYPTED = 3;
+}
+
+// The operating system type of the device.
+// Next id: 7
+enum OsType {
+  // The operating system of the device is not specified or not known.
+  OS_UNSPECIFIED = 0;
+
+  // A desktop Mac operating system.
+  DESKTOP_MAC = 1;
+
+  // A desktop Windows operating system.
+  DESKTOP_WINDOWS = 2;
+
+  // A desktop Linux operating system.
+  DESKTOP_LINUX = 3;
+
+  // A desktop ChromeOS operating system.
+  DESKTOP_CHROME_OS = 6;
+
+  // An Android operating system.
+  ANDROID = 4;
+
+  // An iOS operating system.
+  IOS = 5;
+}
+
+// The degree to which the device is managed by the Cloud organization.
+enum DeviceManagementLevel {
+  // The device's management level is not specified or not known.
+  MANAGEMENT_UNSPECIFIED = 0;
+
+  // The device is not managed.
+  NONE = 1;
+
+  // Basic management is enabled, which is generally limited to monitoring and
+  // wiping the corporate account.
+  BASIC = 2;
+
+  // Complete device management. This includes more thorough monitoring and the
+  // ability to directly manage the device (such as remote wiping). This can be
+  // enabled through the Android Enterprise Platform.
+  COMPLETE = 3;
+}

--- a/protos/google/identity/accesscontextmanager/v1/access_level.proto
+++ b/protos/google/identity/accesscontextmanager/v1/access_level.proto
@@ -1,0 +1,187 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.identity.accesscontextmanager.v1;
+
+import "google/identity/accesscontextmanager/type/device_resources.proto";
+import "google/protobuf/timestamp.proto";
+import "google/type/expr.proto";
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Identity.AccessContextManager.V1";
+option go_package = "google.golang.org/genproto/googleapis/identity/accesscontextmanager/v1;accesscontextmanager";
+option java_multiple_files = true;
+option java_outer_classname = "AccessLevelProto";
+option java_package = "com.google.identity.accesscontextmanager.v1";
+option php_namespace = "Google\\Identity\\AccessContextManager\\V1";
+option ruby_package = "Google::Identity::AccessContextManager::V1";
+option objc_class_prefix = "GACM";
+
+// An `AccessLevel` is a label that can be applied to requests to Google Cloud
+// services, along with a list of requirements necessary for the label to be
+// applied.
+message AccessLevel {
+  // Required. Resource name for the Access Level. The `short_name` component
+  // must begin with a letter and only include alphanumeric and '_'. Format:
+  // `accessPolicies/{policy_id}/accessLevels/{short_name}`. The maximum length
+  // of the `short_name` component is 50 characters.
+  string name = 1;
+
+  // Human readable title. Must be unique within the Policy.
+  string title = 2;
+
+  // Description of the `AccessLevel` and its use. Does not affect behavior.
+  string description = 3;
+
+  // Required. Describes the necessary conditions for the level to apply.
+  oneof level {
+    // A `BasicLevel` composed of `Conditions`.
+    BasicLevel basic = 4;
+
+    // A `CustomLevel` written in the Common Expression Language.
+    CustomLevel custom = 5;
+  }
+
+  // Output only. Time the `AccessLevel` was created in UTC.
+  google.protobuf.Timestamp create_time = 6;
+
+  // Output only. Time the `AccessLevel` was updated in UTC.
+  google.protobuf.Timestamp update_time = 7;
+}
+
+// `BasicLevel` is an `AccessLevel` using a set of recommended features.
+message BasicLevel {
+  // Options for how the `conditions` list should be combined to determine if
+  // this `AccessLevel` is applied. Default is AND.
+  enum ConditionCombiningFunction {
+    // All `Conditions` must be true for the `BasicLevel` to be true.
+    AND = 0;
+
+    // If at least one `Condition` is true, then the `BasicLevel` is true.
+    OR = 1;
+  }
+
+  // Required. A list of requirements for the `AccessLevel` to be granted.
+  repeated Condition conditions = 1;
+
+  // How the `conditions` list should be combined to determine if a request is
+  // granted this `AccessLevel`. If AND is used, each `Condition` in
+  // `conditions` must be satisfied for the `AccessLevel` to be applied. If OR
+  // is used, at least one `Condition` in `conditions` must be satisfied for the
+  // `AccessLevel` to be applied. Default behavior is AND.
+  ConditionCombiningFunction combining_function = 2;
+}
+
+// A condition necessary for an `AccessLevel` to be granted. The Condition is an
+// AND over its fields. So a Condition is true if: 1) the request IP is from one
+// of the listed subnetworks AND 2) the originating device complies with the
+// listed device policy AND 3) all listed access levels are granted AND 4) the
+// request was sent at a time allowed by the DateTimeRestriction.
+message Condition {
+  // CIDR block IP subnetwork specification. May be IPv4 or IPv6. Note that for
+  // a CIDR IP address block, the specified IP address portion must be properly
+  // truncated (i.e. all the host bits must be zero) or the input is considered
+  // malformed. For example, "192.0.2.0/24" is accepted but "192.0.2.1/24" is
+  // not. Similarly, for IPv6, "2001:db8::/32" is accepted whereas
+  // "2001:db8::1/32" is not. The originating IP of a request must be in one of
+  // the listed subnets in order for this Condition to be true. If empty, all IP
+  // addresses are allowed.
+  repeated string ip_subnetworks = 1;
+
+  // Device specific restrictions, all restrictions must hold for the
+  // Condition to be true. If not specified, all devices are allowed.
+  DevicePolicy device_policy = 2;
+
+  // A list of other access levels defined in the same `Policy`, referenced by
+  // resource name. Referencing an `AccessLevel` which does not exist is an
+  // error. All access levels listed must be granted for the Condition
+  // to be true. Example:
+  // "`accessPolicies/MY_POLICY/accessLevels/LEVEL_NAME"`
+  repeated string required_access_levels = 3;
+
+  // Whether to negate the Condition. If true, the Condition becomes a NAND over
+  // its non-empty fields, each field must be false for the Condition overall to
+  // be satisfied. Defaults to false.
+  bool negate = 5;
+
+  // The request must be made by one of the provided user or service
+  // accounts. Groups are not supported.
+  // Syntax:
+  // `user:{emailid}`
+  // `serviceAccount:{emailid}`
+  // If not specified, a request may come from any user.
+  repeated string members = 6;
+
+  // The request must originate from one of the provided countries/regions.
+  // Must be valid ISO 3166-1 alpha-2 codes.
+  repeated string regions = 7;
+}
+
+// `CustomLevel` is an `AccessLevel` using the Cloud Common Expression Language
+// to represent the necessary conditions for the level to apply to a request.
+// See CEL spec at: https://github.com/google/cel-spec
+message CustomLevel {
+  // Required. A Cloud CEL expression evaluating to a boolean.
+  google.type.Expr expr = 1;
+}
+
+// `DevicePolicy` specifies device specific restrictions necessary to acquire a
+// given access level. A `DevicePolicy` specifies requirements for requests from
+// devices to be granted access levels, it does not do any enforcement on the
+// device. `DevicePolicy` acts as an AND over all specified fields, and each
+// repeated field is an OR over its elements. Any unset fields are ignored. For
+// example, if the proto is { os_type : DESKTOP_WINDOWS, os_type :
+// DESKTOP_LINUX, encryption_status: ENCRYPTED}, then the DevicePolicy will be
+// true for requests originating from encrypted Linux desktops and encrypted
+// Windows desktops.
+message DevicePolicy {
+  // Whether or not screenlock is required for the DevicePolicy to be true.
+  // Defaults to `false`.
+  bool require_screenlock = 1;
+
+  // Allowed encryptions statuses, an empty list allows all statuses.
+  repeated google.identity.accesscontextmanager.type.DeviceEncryptionStatus allowed_encryption_statuses = 2;
+
+  // Allowed OS versions, an empty list allows all types and all versions.
+  repeated OsConstraint os_constraints = 3;
+
+  // Allowed device management levels, an empty list allows all management
+  // levels.
+  repeated google.identity.accesscontextmanager.type.DeviceManagementLevel allowed_device_management_levels = 6;
+
+  // Whether the device needs to be approved by the customer admin.
+  bool require_admin_approval = 7;
+
+  // Whether the device needs to be corp owned.
+  bool require_corp_owned = 8;
+}
+
+// A restriction on the OS type and version of devices making requests.
+message OsConstraint {
+  // Required. The allowed OS type.
+  google.identity.accesscontextmanager.type.OsType os_type = 1;
+
+  // The minimum allowed OS version. If not set, any version of this OS
+  // satisfies the constraint. Format: `"major.minor.patch"`.
+  // Examples: `"10.5.301"`, `"9.2.1"`.
+  string minimum_version = 2;
+
+  // Only allows requests from devices with a verified Chrome OS.
+  // Verifications includes requirements that the device is enterprise-managed,
+  // conformant to domain policies, and the caller has permission to call
+  // the API targeted by the request.
+  bool require_verified_chrome_os = 3;
+}

--- a/protos/google/identity/accesscontextmanager/v1/access_policy.proto
+++ b/protos/google/identity/accesscontextmanager/v1/access_policy.proto
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.identity.accesscontextmanager.v1;
+
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Identity.AccessContextManager.V1";
+option go_package = "google.golang.org/genproto/googleapis/identity/accesscontextmanager/v1;accesscontextmanager";
+option java_multiple_files = true;
+option java_outer_classname = "PolicyProto";
+option java_package = "com.google.identity.accesscontextmanager.v1";
+option php_namespace = "Google\\Identity\\AccessContextManager\\V1";
+option ruby_package = "Google::Identity::AccessContextManager::V1";
+option objc_class_prefix = "GACM";
+
+// `AccessPolicy` is a container for `AccessLevels` (which define the necessary
+// attributes to use Google Cloud services) and `ServicePerimeters` (which
+// define regions of services able to freely pass data within a perimeter). An
+// access policy is globally visible within an organization, and the
+// restrictions it specifies apply to all projects within an organization.
+message AccessPolicy {
+  // Output only. Resource name of the `AccessPolicy`. Format:
+  // `accessPolicies/{policy_id}`
+  string name = 1;
+
+  // Required. The parent of this `AccessPolicy` in the Cloud Resource
+  // Hierarchy. Currently immutable once created. Format:
+  // `organizations/{organization_id}`
+  string parent = 2;
+
+  // Required. Human readable title. Does not affect behavior.
+  string title = 3;
+
+  // Output only. Time the `AccessPolicy` was created in UTC.
+  google.protobuf.Timestamp create_time = 4;
+
+  // Output only. Time the `AccessPolicy` was updated in UTC.
+  google.protobuf.Timestamp update_time = 5;
+
+  // Output only. An opaque identifier for the current version of the
+  // `AccessPolicy`. This will always be a strongly validated etag, meaning that
+  // two Access Polices will be identical if and only if their etags are
+  // identical. Clients should not expect this to be in any specific format.
+  string etag = 6;
+}

--- a/protos/google/identity/accesscontextmanager/v1/service_perimeter.proto
+++ b/protos/google/identity/accesscontextmanager/v1/service_perimeter.proto
@@ -1,0 +1,152 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.identity.accesscontextmanager.v1;
+
+import "google/protobuf/timestamp.proto";
+import "google/api/annotations.proto";
+
+option csharp_namespace = "Google.Identity.AccessContextManager.V1";
+option go_package = "google.golang.org/genproto/googleapis/identity/accesscontextmanager/v1;accesscontextmanager";
+option java_multiple_files = true;
+option java_outer_classname = "ServicePerimeterProto";
+option java_package = "com.google.identity.accesscontextmanager.v1";
+option php_namespace = "Google\\Identity\\AccessContextManager\\V1";
+option ruby_package = "Google::Identity::AccessContextManager::V1";
+option objc_class_prefix = "GACM";
+
+// `ServicePerimeter` describes a set of Google Cloud resources which can freely
+// import and export data amongst themselves, but not export outside of the
+// `ServicePerimeter`. If a request with a source within this `ServicePerimeter`
+// has a target outside of the `ServicePerimeter`, the request will be blocked.
+// Otherwise the request is allowed. There are two types of Service Perimeter -
+// Regular and Bridge. Regular Service Perimeters cannot overlap, a single
+// Google Cloud project can only belong to a single regular Service Perimeter.
+// Service Perimeter Bridges can contain only Google Cloud projects as members,
+// a single Google Cloud project may belong to multiple Service Perimeter
+// Bridges.
+message ServicePerimeter {
+  // Specifies the type of the Perimeter. There are two types: regular and
+  // bridge. Regular Service Perimeter contains resources, access levels, and
+  // restricted services. Every resource can be in at most ONE
+  // regular Service Perimeter.
+  //
+  // In addition to being in a regular service perimeter, a resource can also
+  // be in zero or more perimeter bridges.  A perimeter bridge only contains
+  // resources.  Cross project operations are permitted if all effected
+  // resources share some perimeter (whether bridge or regular). Perimeter
+  // Bridge does not contain access levels or services: those are governed
+  // entirely by the regular perimeter that resource is in.
+  //
+  // Perimeter Bridges are typically useful when building more complex toplogies
+  // with many independent perimeters that need to share some data with a common
+  // perimeter, but should not be able to share data among themselves.
+  enum PerimeterType {
+    // Regular Perimeter.
+    PERIMETER_TYPE_REGULAR = 0;
+
+    // Perimeter Bridge.
+    PERIMETER_TYPE_BRIDGE = 1;
+  }
+
+  // Required. Resource name for the ServicePerimeter.  The `short_name`
+  // component must begin with a letter and only include alphanumeric and '_'.
+  // Format: `accessPolicies/{policy_id}/servicePerimeters/{short_name}`
+  string name = 1;
+
+  // Human readable title. Must be unique within the Policy.
+  string title = 2;
+
+  // Description of the `ServicePerimeter` and its use. Does not affect
+  // behavior.
+  string description = 3;
+
+  // Output only. Time the `ServicePerimeter` was created in UTC.
+  google.protobuf.Timestamp create_time = 4;
+
+  // Output only. Time the `ServicePerimeter` was updated in UTC.
+  google.protobuf.Timestamp update_time = 5;
+
+  // Perimeter type indicator. A single project is
+  // allowed to be a member of single regular perimeter, but multiple service
+  // perimeter bridges. A project cannot be a included in a perimeter bridge
+  // without being included in regular perimeter. For perimeter bridges,
+  // the restricted service list as well as access level lists must be
+  // empty.
+  PerimeterType perimeter_type = 6;
+
+  // Current ServicePerimeter configuration. Specifies sets of resources,
+  // restricted services and access levels that determine perimeter
+  // content and boundaries.
+  ServicePerimeterConfig status = 7;
+
+  // Proposed (or dry run) ServicePerimeter configuration. This configuration
+  // allows to specify and test ServicePerimeter configuration without enforcing
+  // actual access restrictions. Only allowed to be set when the
+  // "use_explicit_dry_run_spec" flag is set.
+  ServicePerimeterConfig spec = 8;
+
+  // Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly
+  // exists  for all Service Perimeters, and that spec is identical to the
+  // status for those Service Perimeters. When this flag is set, it inhibits the
+  // generation of the implicit spec, thereby allowing the user to explicitly
+  // provide a configuration ("spec") to use in a dry-run version of the Service
+  // Perimeter. This allows the user to test changes to the enforced config
+  // ("status") without actually enforcing them. This testing is done through
+  // analyzing the differences between currently enforced and suggested
+  // restrictions. use_explicit_dry_run_spec must bet set to True if any of the
+  // fields in the spec are set to non-default values.
+  bool use_explicit_dry_run_spec = 9;
+}
+
+// `ServicePerimeterConfig` specifies a set of Google Cloud resources that
+// describe specific Service Perimeter configuration.
+message ServicePerimeterConfig {
+  // Specifies how APIs are allowed to communicate within the Service
+  // Perimeter.
+  message VpcAccessibleServices {
+    // Whether to restrict API calls within the Service Perimeter to the list of
+    // APIs specified in 'allowed_services'.
+    bool enable_restriction = 1;
+
+    // The list of APIs usable within the Service Perimeter. Must be empty
+    // unless 'enable_restriction' is True.
+    repeated string allowed_services = 2;
+  }
+
+  // A list of Google Cloud resources that are inside of the service perimeter.
+  // Currently only projects are allowed. Format: `projects/{project_number}`
+  repeated string resources = 1;
+
+  // A list of `AccessLevel` resource names that allow resources within the
+  // `ServicePerimeter` to be accessed from the internet. `AccessLevels` listed
+  // must be in the same policy as this `ServicePerimeter`. Referencing a
+  // nonexistent `AccessLevel` is a syntax error. If no `AccessLevel` names are
+  // listed, resources within the perimeter can only be accessed via Google
+  // Cloud calls with request origins within the perimeter. Example:
+  // `"accessPolicies/MY_POLICY/accessLevels/MY_LEVEL"`.
+  // For Service Perimeter Bridge, must be empty.
+  repeated string access_levels = 2;
+
+  // Google Cloud services that are subject to the Service Perimeter
+  // restrictions. For example, if `storage.googleapis.com` is specified, access
+  // to the storage buckets inside the perimeter must meet the perimeter's
+  // access restrictions.
+  repeated string restricted_services = 4;
+
+  // Configuration for APIs allowed within Perimeter.
+  VpcAccessibleServices vpc_accessible_services = 10;
+}

--- a/protos/protos.d.ts
+++ b/protos/protos.d.ts
@@ -1553,15 +1553,6 @@ export namespace google {
                     public toJSON(): { [k: string]: any };
                 }
 
-                /** ContentType enum. */
-                enum ContentType {
-                    CONTENT_TYPE_UNSPECIFIED = 0,
-                    RESOURCE = 1,
-                    IAM_POLICY = 2,
-                    ORG_POLICY = 4,
-                    ACCESS_POLICY = 5
-                }
-
                 /** Properties of a FeedOutputConfig. */
                 interface IFeedOutputConfig {
 
@@ -1767,6 +1758,15 @@ export namespace google {
                      * @returns JSON object
                      */
                     public toJSON(): { [k: string]: any };
+                }
+
+                /** ContentType enum. */
+                enum ContentType {
+                    CONTENT_TYPE_UNSPECIFIED = 0,
+                    RESOURCE = 1,
+                    IAM_POLICY = 2,
+                    ORG_POLICY = 4,
+                    ACCESS_POLICY = 5
                 }
 
                 /** Properties of a TemporalAsset. */
@@ -1982,6 +1982,18 @@ export namespace google {
                     /** Asset iamPolicy */
                     iamPolicy?: (google.iam.v1.IPolicy|null);
 
+                    /** Asset orgPolicy */
+                    orgPolicy?: (google.cloud.orgpolicy.v1.IPolicy[]|null);
+
+                    /** Asset accessPolicy */
+                    accessPolicy?: (google.identity.accesscontextmanager.v1.IAccessPolicy|null);
+
+                    /** Asset accessLevel */
+                    accessLevel?: (google.identity.accesscontextmanager.v1.IAccessLevel|null);
+
+                    /** Asset servicePerimeter */
+                    servicePerimeter?: (google.identity.accesscontextmanager.v1.IServicePerimeter|null);
+
                     /** Asset ancestors */
                     ancestors?: (string[]|null);
                 }
@@ -2007,8 +2019,23 @@ export namespace google {
                     /** Asset iamPolicy. */
                     public iamPolicy?: (google.iam.v1.IPolicy|null);
 
+                    /** Asset orgPolicy. */
+                    public orgPolicy: google.cloud.orgpolicy.v1.IPolicy[];
+
+                    /** Asset accessPolicy. */
+                    public accessPolicy?: (google.identity.accesscontextmanager.v1.IAccessPolicy|null);
+
+                    /** Asset accessLevel. */
+                    public accessLevel?: (google.identity.accesscontextmanager.v1.IAccessLevel|null);
+
+                    /** Asset servicePerimeter. */
+                    public servicePerimeter?: (google.identity.accesscontextmanager.v1.IServicePerimeter|null);
+
                     /** Asset ancestors. */
                     public ancestors: string[];
+
+                    /** Asset accessContextPolicy. */
+                    public accessContextPolicy?: ("accessPolicy"|"accessLevel"|"servicePerimeter");
 
                     /**
                      * Creates a new Asset instance using the specified properties.
@@ -7824,6 +7851,444 @@ export namespace google {
                 }
             }
         }
+
+        /** Namespace orgpolicy. */
+        namespace orgpolicy {
+
+            /** Namespace v1. */
+            namespace v1 {
+
+                /** Properties of a Policy. */
+                interface IPolicy {
+
+                    /** Policy version */
+                    version?: (number|null);
+
+                    /** Policy constraint */
+                    constraint?: (string|null);
+
+                    /** Policy etag */
+                    etag?: (Uint8Array|string|null);
+
+                    /** Policy updateTime */
+                    updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** Policy listPolicy */
+                    listPolicy?: (google.cloud.orgpolicy.v1.Policy.IListPolicy|null);
+
+                    /** Policy booleanPolicy */
+                    booleanPolicy?: (google.cloud.orgpolicy.v1.Policy.IBooleanPolicy|null);
+
+                    /** Policy restoreDefault */
+                    restoreDefault?: (google.cloud.orgpolicy.v1.Policy.IRestoreDefault|null);
+                }
+
+                /** Represents a Policy. */
+                class Policy implements IPolicy {
+
+                    /**
+                     * Constructs a new Policy.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.cloud.orgpolicy.v1.IPolicy);
+
+                    /** Policy version. */
+                    public version: number;
+
+                    /** Policy constraint. */
+                    public constraint: string;
+
+                    /** Policy etag. */
+                    public etag: (Uint8Array|string);
+
+                    /** Policy updateTime. */
+                    public updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** Policy listPolicy. */
+                    public listPolicy?: (google.cloud.orgpolicy.v1.Policy.IListPolicy|null);
+
+                    /** Policy booleanPolicy. */
+                    public booleanPolicy?: (google.cloud.orgpolicy.v1.Policy.IBooleanPolicy|null);
+
+                    /** Policy restoreDefault. */
+                    public restoreDefault?: (google.cloud.orgpolicy.v1.Policy.IRestoreDefault|null);
+
+                    /** Policy policyType. */
+                    public policyType?: ("listPolicy"|"booleanPolicy"|"restoreDefault");
+
+                    /**
+                     * Creates a new Policy instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns Policy instance
+                     */
+                    public static create(properties?: google.cloud.orgpolicy.v1.IPolicy): google.cloud.orgpolicy.v1.Policy;
+
+                    /**
+                     * Encodes the specified Policy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.verify|verify} messages.
+                     * @param message Policy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.cloud.orgpolicy.v1.IPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified Policy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.verify|verify} messages.
+                     * @param message Policy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.cloud.orgpolicy.v1.IPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a Policy message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns Policy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.orgpolicy.v1.Policy;
+
+                    /**
+                     * Decodes a Policy message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns Policy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.orgpolicy.v1.Policy;
+
+                    /**
+                     * Verifies a Policy message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a Policy message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Policy
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.cloud.orgpolicy.v1.Policy;
+
+                    /**
+                     * Creates a plain object from a Policy message. Also converts values to other types if specified.
+                     * @param message Policy
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.cloud.orgpolicy.v1.Policy, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Policy to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                namespace Policy {
+
+                    /** Properties of a ListPolicy. */
+                    interface IListPolicy {
+
+                        /** ListPolicy allowedValues */
+                        allowedValues?: (string[]|null);
+
+                        /** ListPolicy deniedValues */
+                        deniedValues?: (string[]|null);
+
+                        /** ListPolicy allValues */
+                        allValues?: (google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues|keyof typeof google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues|null);
+
+                        /** ListPolicy suggestedValue */
+                        suggestedValue?: (string|null);
+
+                        /** ListPolicy inheritFromParent */
+                        inheritFromParent?: (boolean|null);
+                    }
+
+                    /** Represents a ListPolicy. */
+                    class ListPolicy implements IListPolicy {
+
+                        /**
+                         * Constructs a new ListPolicy.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: google.cloud.orgpolicy.v1.Policy.IListPolicy);
+
+                        /** ListPolicy allowedValues. */
+                        public allowedValues: string[];
+
+                        /** ListPolicy deniedValues. */
+                        public deniedValues: string[];
+
+                        /** ListPolicy allValues. */
+                        public allValues: (google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues|keyof typeof google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues);
+
+                        /** ListPolicy suggestedValue. */
+                        public suggestedValue: string;
+
+                        /** ListPolicy inheritFromParent. */
+                        public inheritFromParent: boolean;
+
+                        /**
+                         * Creates a new ListPolicy instance using the specified properties.
+                         * @param [properties] Properties to set
+                         * @returns ListPolicy instance
+                         */
+                        public static create(properties?: google.cloud.orgpolicy.v1.Policy.IListPolicy): google.cloud.orgpolicy.v1.Policy.ListPolicy;
+
+                        /**
+                         * Encodes the specified ListPolicy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.ListPolicy.verify|verify} messages.
+                         * @param message ListPolicy message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encode(message: google.cloud.orgpolicy.v1.Policy.IListPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Encodes the specified ListPolicy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.ListPolicy.verify|verify} messages.
+                         * @param message ListPolicy message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encodeDelimited(message: google.cloud.orgpolicy.v1.Policy.IListPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Decodes a ListPolicy message from the specified reader or buffer.
+                         * @param reader Reader or buffer to decode from
+                         * @param [length] Message length if known beforehand
+                         * @returns ListPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.orgpolicy.v1.Policy.ListPolicy;
+
+                        /**
+                         * Decodes a ListPolicy message from the specified reader or buffer, length delimited.
+                         * @param reader Reader or buffer to decode from
+                         * @returns ListPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.orgpolicy.v1.Policy.ListPolicy;
+
+                        /**
+                         * Verifies a ListPolicy message.
+                         * @param message Plain object to verify
+                         * @returns `null` if valid, otherwise the reason why it is not
+                         */
+                        public static verify(message: { [k: string]: any }): (string|null);
+
+                        /**
+                         * Creates a ListPolicy message from a plain object. Also converts values to their respective internal types.
+                         * @param object Plain object
+                         * @returns ListPolicy
+                         */
+                        public static fromObject(object: { [k: string]: any }): google.cloud.orgpolicy.v1.Policy.ListPolicy;
+
+                        /**
+                         * Creates a plain object from a ListPolicy message. Also converts values to other types if specified.
+                         * @param message ListPolicy
+                         * @param [options] Conversion options
+                         * @returns Plain object
+                         */
+                        public static toObject(message: google.cloud.orgpolicy.v1.Policy.ListPolicy, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                        /**
+                         * Converts this ListPolicy to JSON.
+                         * @returns JSON object
+                         */
+                        public toJSON(): { [k: string]: any };
+                    }
+
+                    namespace ListPolicy {
+
+                        /** AllValues enum. */
+                        enum AllValues {
+                            ALL_VALUES_UNSPECIFIED = 0,
+                            ALLOW = 1,
+                            DENY = 2
+                        }
+                    }
+
+                    /** Properties of a BooleanPolicy. */
+                    interface IBooleanPolicy {
+
+                        /** BooleanPolicy enforced */
+                        enforced?: (boolean|null);
+                    }
+
+                    /** Represents a BooleanPolicy. */
+                    class BooleanPolicy implements IBooleanPolicy {
+
+                        /**
+                         * Constructs a new BooleanPolicy.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: google.cloud.orgpolicy.v1.Policy.IBooleanPolicy);
+
+                        /** BooleanPolicy enforced. */
+                        public enforced: boolean;
+
+                        /**
+                         * Creates a new BooleanPolicy instance using the specified properties.
+                         * @param [properties] Properties to set
+                         * @returns BooleanPolicy instance
+                         */
+                        public static create(properties?: google.cloud.orgpolicy.v1.Policy.IBooleanPolicy): google.cloud.orgpolicy.v1.Policy.BooleanPolicy;
+
+                        /**
+                         * Encodes the specified BooleanPolicy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.BooleanPolicy.verify|verify} messages.
+                         * @param message BooleanPolicy message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encode(message: google.cloud.orgpolicy.v1.Policy.IBooleanPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Encodes the specified BooleanPolicy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.BooleanPolicy.verify|verify} messages.
+                         * @param message BooleanPolicy message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encodeDelimited(message: google.cloud.orgpolicy.v1.Policy.IBooleanPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Decodes a BooleanPolicy message from the specified reader or buffer.
+                         * @param reader Reader or buffer to decode from
+                         * @param [length] Message length if known beforehand
+                         * @returns BooleanPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.orgpolicy.v1.Policy.BooleanPolicy;
+
+                        /**
+                         * Decodes a BooleanPolicy message from the specified reader or buffer, length delimited.
+                         * @param reader Reader or buffer to decode from
+                         * @returns BooleanPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.orgpolicy.v1.Policy.BooleanPolicy;
+
+                        /**
+                         * Verifies a BooleanPolicy message.
+                         * @param message Plain object to verify
+                         * @returns `null` if valid, otherwise the reason why it is not
+                         */
+                        public static verify(message: { [k: string]: any }): (string|null);
+
+                        /**
+                         * Creates a BooleanPolicy message from a plain object. Also converts values to their respective internal types.
+                         * @param object Plain object
+                         * @returns BooleanPolicy
+                         */
+                        public static fromObject(object: { [k: string]: any }): google.cloud.orgpolicy.v1.Policy.BooleanPolicy;
+
+                        /**
+                         * Creates a plain object from a BooleanPolicy message. Also converts values to other types if specified.
+                         * @param message BooleanPolicy
+                         * @param [options] Conversion options
+                         * @returns Plain object
+                         */
+                        public static toObject(message: google.cloud.orgpolicy.v1.Policy.BooleanPolicy, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                        /**
+                         * Converts this BooleanPolicy to JSON.
+                         * @returns JSON object
+                         */
+                        public toJSON(): { [k: string]: any };
+                    }
+
+                    /** Properties of a RestoreDefault. */
+                    interface IRestoreDefault {
+                    }
+
+                    /** Represents a RestoreDefault. */
+                    class RestoreDefault implements IRestoreDefault {
+
+                        /**
+                         * Constructs a new RestoreDefault.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: google.cloud.orgpolicy.v1.Policy.IRestoreDefault);
+
+                        /**
+                         * Creates a new RestoreDefault instance using the specified properties.
+                         * @param [properties] Properties to set
+                         * @returns RestoreDefault instance
+                         */
+                        public static create(properties?: google.cloud.orgpolicy.v1.Policy.IRestoreDefault): google.cloud.orgpolicy.v1.Policy.RestoreDefault;
+
+                        /**
+                         * Encodes the specified RestoreDefault message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.RestoreDefault.verify|verify} messages.
+                         * @param message RestoreDefault message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encode(message: google.cloud.orgpolicy.v1.Policy.IRestoreDefault, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Encodes the specified RestoreDefault message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.RestoreDefault.verify|verify} messages.
+                         * @param message RestoreDefault message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encodeDelimited(message: google.cloud.orgpolicy.v1.Policy.IRestoreDefault, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Decodes a RestoreDefault message from the specified reader or buffer.
+                         * @param reader Reader or buffer to decode from
+                         * @param [length] Message length if known beforehand
+                         * @returns RestoreDefault
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.orgpolicy.v1.Policy.RestoreDefault;
+
+                        /**
+                         * Decodes a RestoreDefault message from the specified reader or buffer, length delimited.
+                         * @param reader Reader or buffer to decode from
+                         * @returns RestoreDefault
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.orgpolicy.v1.Policy.RestoreDefault;
+
+                        /**
+                         * Verifies a RestoreDefault message.
+                         * @param message Plain object to verify
+                         * @returns `null` if valid, otherwise the reason why it is not
+                         */
+                        public static verify(message: { [k: string]: any }): (string|null);
+
+                        /**
+                         * Creates a RestoreDefault message from a plain object. Also converts values to their respective internal types.
+                         * @param object Plain object
+                         * @returns RestoreDefault
+                         */
+                        public static fromObject(object: { [k: string]: any }): google.cloud.orgpolicy.v1.Policy.RestoreDefault;
+
+                        /**
+                         * Creates a plain object from a RestoreDefault message. Also converts values to other types if specified.
+                         * @param message RestoreDefault
+                         * @param [options] Conversion options
+                         * @returns Plain object
+                         */
+                        public static toObject(message: google.cloud.orgpolicy.v1.Policy.RestoreDefault, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                        /**
+                         * Converts this RestoreDefault to JSON.
+                         * @returns JSON object
+                         */
+                        public toJSON(): { [k: string]: any };
+                    }
+                }
+            }
+        }
     }
 
     /** Namespace api. */
@@ -11531,6 +11996,186 @@ export namespace google {
             }
         }
 
+        /** Properties of an Empty. */
+        interface IEmpty {
+        }
+
+        /** Represents an Empty. */
+        class Empty implements IEmpty {
+
+            /**
+             * Constructs a new Empty.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.IEmpty);
+
+            /**
+             * Creates a new Empty instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Empty instance
+             */
+            public static create(properties?: google.protobuf.IEmpty): google.protobuf.Empty;
+
+            /**
+             * Encodes the specified Empty message. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
+             * @param message Empty message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Empty message, length delimited. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
+             * @param message Empty message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes an Empty message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Empty
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Empty;
+
+            /**
+             * Decodes an Empty message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Empty
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Empty;
+
+            /**
+             * Verifies an Empty message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates an Empty message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Empty
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.Empty;
+
+            /**
+             * Creates a plain object from an Empty message. Also converts values to other types if specified.
+             * @param message Empty
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.Empty, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Empty to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
+        /** Properties of a Timestamp. */
+        interface ITimestamp {
+
+            /** Timestamp seconds */
+            seconds?: (number|Long|string|null);
+
+            /** Timestamp nanos */
+            nanos?: (number|null);
+        }
+
+        /** Represents a Timestamp. */
+        class Timestamp implements ITimestamp {
+
+            /**
+             * Constructs a new Timestamp.
+             * @param [properties] Properties to set
+             */
+            constructor(properties?: google.protobuf.ITimestamp);
+
+            /** Timestamp seconds. */
+            public seconds: (number|Long|string);
+
+            /** Timestamp nanos. */
+            public nanos: number;
+
+            /**
+             * Creates a new Timestamp instance using the specified properties.
+             * @param [properties] Properties to set
+             * @returns Timestamp instance
+             */
+            public static create(properties?: google.protobuf.ITimestamp): google.protobuf.Timestamp;
+
+            /**
+             * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @param message Timestamp message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encode(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+             * @param message Timestamp message or plain object to encode
+             * @param [writer] Writer to encode to
+             * @returns Writer
+             */
+            public static encodeDelimited(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer.
+             * @param reader Reader or buffer to decode from
+             * @param [length] Message length if known beforehand
+             * @returns Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Timestamp;
+
+            /**
+             * Decodes a Timestamp message from the specified reader or buffer, length delimited.
+             * @param reader Reader or buffer to decode from
+             * @returns Timestamp
+             * @throws {Error} If the payload is not a reader or valid buffer
+             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+             */
+            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Timestamp;
+
+            /**
+             * Verifies a Timestamp message.
+             * @param message Plain object to verify
+             * @returns `null` if valid, otherwise the reason why it is not
+             */
+            public static verify(message: { [k: string]: any }): (string|null);
+
+            /**
+             * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
+             * @param object Plain object
+             * @returns Timestamp
+             */
+            public static fromObject(object: { [k: string]: any }): google.protobuf.Timestamp;
+
+            /**
+             * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
+             * @param message Timestamp
+             * @param [options] Conversion options
+             * @returns Plain object
+             */
+            public static toObject(message: google.protobuf.Timestamp, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+            /**
+             * Converts this Timestamp to JSON.
+             * @returns JSON object
+             */
+            public toJSON(): { [k: string]: any };
+        }
+
         /** Properties of an Any. */
         interface IAny {
 
@@ -11935,102 +12580,6 @@ export namespace google {
             public toJSON(): { [k: string]: any };
         }
 
-        /** Properties of a Timestamp. */
-        interface ITimestamp {
-
-            /** Timestamp seconds */
-            seconds?: (number|Long|string|null);
-
-            /** Timestamp nanos */
-            nanos?: (number|null);
-        }
-
-        /** Represents a Timestamp. */
-        class Timestamp implements ITimestamp {
-
-            /**
-             * Constructs a new Timestamp.
-             * @param [properties] Properties to set
-             */
-            constructor(properties?: google.protobuf.ITimestamp);
-
-            /** Timestamp seconds. */
-            public seconds: (number|Long|string);
-
-            /** Timestamp nanos. */
-            public nanos: number;
-
-            /**
-             * Creates a new Timestamp instance using the specified properties.
-             * @param [properties] Properties to set
-             * @returns Timestamp instance
-             */
-            public static create(properties?: google.protobuf.ITimestamp): google.protobuf.Timestamp;
-
-            /**
-             * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-             * @param message Timestamp message or plain object to encode
-             * @param [writer] Writer to encode to
-             * @returns Writer
-             */
-            public static encode(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
-
-            /**
-             * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-             * @param message Timestamp message or plain object to encode
-             * @param [writer] Writer to encode to
-             * @returns Writer
-             */
-            public static encodeDelimited(message: google.protobuf.ITimestamp, writer?: $protobuf.Writer): $protobuf.Writer;
-
-            /**
-             * Decodes a Timestamp message from the specified reader or buffer.
-             * @param reader Reader or buffer to decode from
-             * @param [length] Message length if known beforehand
-             * @returns Timestamp
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Timestamp;
-
-            /**
-             * Decodes a Timestamp message from the specified reader or buffer, length delimited.
-             * @param reader Reader or buffer to decode from
-             * @returns Timestamp
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Timestamp;
-
-            /**
-             * Verifies a Timestamp message.
-             * @param message Plain object to verify
-             * @returns `null` if valid, otherwise the reason why it is not
-             */
-            public static verify(message: { [k: string]: any }): (string|null);
-
-            /**
-             * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
-             * @param object Plain object
-             * @returns Timestamp
-             */
-            public static fromObject(object: { [k: string]: any }): google.protobuf.Timestamp;
-
-            /**
-             * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
-             * @param message Timestamp
-             * @param [options] Conversion options
-             * @returns Plain object
-             */
-            public static toObject(message: google.protobuf.Timestamp, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-            /**
-             * Converts this Timestamp to JSON.
-             * @returns JSON object
-             */
-            public toJSON(): { [k: string]: any };
-        }
-
         /** Properties of a Duration. */
         interface IDuration {
 
@@ -12122,90 +12671,6 @@ export namespace google {
 
             /**
              * Converts this Duration to JSON.
-             * @returns JSON object
-             */
-            public toJSON(): { [k: string]: any };
-        }
-
-        /** Properties of an Empty. */
-        interface IEmpty {
-        }
-
-        /** Represents an Empty. */
-        class Empty implements IEmpty {
-
-            /**
-             * Constructs a new Empty.
-             * @param [properties] Properties to set
-             */
-            constructor(properties?: google.protobuf.IEmpty);
-
-            /**
-             * Creates a new Empty instance using the specified properties.
-             * @param [properties] Properties to set
-             * @returns Empty instance
-             */
-            public static create(properties?: google.protobuf.IEmpty): google.protobuf.Empty;
-
-            /**
-             * Encodes the specified Empty message. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
-             * @param message Empty message or plain object to encode
-             * @param [writer] Writer to encode to
-             * @returns Writer
-             */
-            public static encode(message: google.protobuf.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
-
-            /**
-             * Encodes the specified Empty message, length delimited. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
-             * @param message Empty message or plain object to encode
-             * @param [writer] Writer to encode to
-             * @returns Writer
-             */
-            public static encodeDelimited(message: google.protobuf.IEmpty, writer?: $protobuf.Writer): $protobuf.Writer;
-
-            /**
-             * Decodes an Empty message from the specified reader or buffer.
-             * @param reader Reader or buffer to decode from
-             * @param [length] Message length if known beforehand
-             * @returns Empty
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.protobuf.Empty;
-
-            /**
-             * Decodes an Empty message from the specified reader or buffer, length delimited.
-             * @param reader Reader or buffer to decode from
-             * @returns Empty
-             * @throws {Error} If the payload is not a reader or valid buffer
-             * @throws {$protobuf.util.ProtocolError} If required fields are missing
-             */
-            public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.protobuf.Empty;
-
-            /**
-             * Verifies an Empty message.
-             * @param message Plain object to verify
-             * @returns `null` if valid, otherwise the reason why it is not
-             */
-            public static verify(message: { [k: string]: any }): (string|null);
-
-            /**
-             * Creates an Empty message from a plain object. Also converts values to their respective internal types.
-             * @param object Plain object
-             * @returns Empty
-             */
-            public static fromObject(object: { [k: string]: any }): google.protobuf.Empty;
-
-            /**
-             * Creates a plain object from an Empty message. Also converts values to other types if specified.
-             * @param message Empty
-             * @param [options] Conversion options
-             * @returns Plain object
-             */
-            public static toObject(message: google.protobuf.Empty, options?: $protobuf.IConversionOptions): { [k: string]: any };
-
-            /**
-             * Converts this Empty to JSON.
              * @returns JSON object
              */
             public toJSON(): { [k: string]: any };
@@ -12955,6 +13420,1189 @@ export namespace google {
              * @returns JSON object
              */
             public toJSON(): { [k: string]: any };
+        }
+    }
+
+    /** Namespace identity. */
+    namespace identity {
+
+        /** Namespace accesscontextmanager. */
+        namespace accesscontextmanager {
+
+            /** Namespace v1. */
+            namespace v1 {
+
+                /** Properties of an AccessLevel. */
+                interface IAccessLevel {
+
+                    /** AccessLevel name */
+                    name?: (string|null);
+
+                    /** AccessLevel title */
+                    title?: (string|null);
+
+                    /** AccessLevel description */
+                    description?: (string|null);
+
+                    /** AccessLevel basic */
+                    basic?: (google.identity.accesscontextmanager.v1.IBasicLevel|null);
+
+                    /** AccessLevel custom */
+                    custom?: (google.identity.accesscontextmanager.v1.ICustomLevel|null);
+
+                    /** AccessLevel createTime */
+                    createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessLevel updateTime */
+                    updateTime?: (google.protobuf.ITimestamp|null);
+                }
+
+                /** Represents an AccessLevel. */
+                class AccessLevel implements IAccessLevel {
+
+                    /**
+                     * Constructs a new AccessLevel.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IAccessLevel);
+
+                    /** AccessLevel name. */
+                    public name: string;
+
+                    /** AccessLevel title. */
+                    public title: string;
+
+                    /** AccessLevel description. */
+                    public description: string;
+
+                    /** AccessLevel basic. */
+                    public basic?: (google.identity.accesscontextmanager.v1.IBasicLevel|null);
+
+                    /** AccessLevel custom. */
+                    public custom?: (google.identity.accesscontextmanager.v1.ICustomLevel|null);
+
+                    /** AccessLevel createTime. */
+                    public createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessLevel updateTime. */
+                    public updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessLevel level. */
+                    public level?: ("basic"|"custom");
+
+                    /**
+                     * Creates a new AccessLevel instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns AccessLevel instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IAccessLevel): google.identity.accesscontextmanager.v1.AccessLevel;
+
+                    /**
+                     * Encodes the specified AccessLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessLevel.verify|verify} messages.
+                     * @param message AccessLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IAccessLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified AccessLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessLevel.verify|verify} messages.
+                     * @param message AccessLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IAccessLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes an AccessLevel message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns AccessLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.AccessLevel;
+
+                    /**
+                     * Decodes an AccessLevel message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns AccessLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.AccessLevel;
+
+                    /**
+                     * Verifies an AccessLevel message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an AccessLevel message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns AccessLevel
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.AccessLevel;
+
+                    /**
+                     * Creates a plain object from an AccessLevel message. Also converts values to other types if specified.
+                     * @param message AccessLevel
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.AccessLevel, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this AccessLevel to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a BasicLevel. */
+                interface IBasicLevel {
+
+                    /** BasicLevel conditions */
+                    conditions?: (google.identity.accesscontextmanager.v1.ICondition[]|null);
+
+                    /** BasicLevel combiningFunction */
+                    combiningFunction?: (google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction|keyof typeof google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction|null);
+                }
+
+                /** Represents a BasicLevel. */
+                class BasicLevel implements IBasicLevel {
+
+                    /**
+                     * Constructs a new BasicLevel.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IBasicLevel);
+
+                    /** BasicLevel conditions. */
+                    public conditions: google.identity.accesscontextmanager.v1.ICondition[];
+
+                    /** BasicLevel combiningFunction. */
+                    public combiningFunction: (google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction|keyof typeof google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction);
+
+                    /**
+                     * Creates a new BasicLevel instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns BasicLevel instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IBasicLevel): google.identity.accesscontextmanager.v1.BasicLevel;
+
+                    /**
+                     * Encodes the specified BasicLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.BasicLevel.verify|verify} messages.
+                     * @param message BasicLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IBasicLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified BasicLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.BasicLevel.verify|verify} messages.
+                     * @param message BasicLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IBasicLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a BasicLevel message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns BasicLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.BasicLevel;
+
+                    /**
+                     * Decodes a BasicLevel message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns BasicLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.BasicLevel;
+
+                    /**
+                     * Verifies a BasicLevel message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a BasicLevel message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns BasicLevel
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.BasicLevel;
+
+                    /**
+                     * Creates a plain object from a BasicLevel message. Also converts values to other types if specified.
+                     * @param message BasicLevel
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.BasicLevel, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this BasicLevel to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                namespace BasicLevel {
+
+                    /** ConditionCombiningFunction enum. */
+                    enum ConditionCombiningFunction {
+                        AND = 0,
+                        OR = 1
+                    }
+                }
+
+                /** Properties of a Condition. */
+                interface ICondition {
+
+                    /** Condition ipSubnetworks */
+                    ipSubnetworks?: (string[]|null);
+
+                    /** Condition devicePolicy */
+                    devicePolicy?: (google.identity.accesscontextmanager.v1.IDevicePolicy|null);
+
+                    /** Condition requiredAccessLevels */
+                    requiredAccessLevels?: (string[]|null);
+
+                    /** Condition negate */
+                    negate?: (boolean|null);
+
+                    /** Condition members */
+                    members?: (string[]|null);
+
+                    /** Condition regions */
+                    regions?: (string[]|null);
+                }
+
+                /** Represents a Condition. */
+                class Condition implements ICondition {
+
+                    /**
+                     * Constructs a new Condition.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.ICondition);
+
+                    /** Condition ipSubnetworks. */
+                    public ipSubnetworks: string[];
+
+                    /** Condition devicePolicy. */
+                    public devicePolicy?: (google.identity.accesscontextmanager.v1.IDevicePolicy|null);
+
+                    /** Condition requiredAccessLevels. */
+                    public requiredAccessLevels: string[];
+
+                    /** Condition negate. */
+                    public negate: boolean;
+
+                    /** Condition members. */
+                    public members: string[];
+
+                    /** Condition regions. */
+                    public regions: string[];
+
+                    /**
+                     * Creates a new Condition instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns Condition instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.ICondition): google.identity.accesscontextmanager.v1.Condition;
+
+                    /**
+                     * Encodes the specified Condition message. Does not implicitly {@link google.identity.accesscontextmanager.v1.Condition.verify|verify} messages.
+                     * @param message Condition message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.ICondition, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified Condition message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.Condition.verify|verify} messages.
+                     * @param message Condition message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.ICondition, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a Condition message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns Condition
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.Condition;
+
+                    /**
+                     * Decodes a Condition message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns Condition
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.Condition;
+
+                    /**
+                     * Verifies a Condition message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a Condition message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns Condition
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.Condition;
+
+                    /**
+                     * Creates a plain object from a Condition message. Also converts values to other types if specified.
+                     * @param message Condition
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.Condition, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this Condition to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a CustomLevel. */
+                interface ICustomLevel {
+
+                    /** CustomLevel expr */
+                    expr?: (google.type.IExpr|null);
+                }
+
+                /** Represents a CustomLevel. */
+                class CustomLevel implements ICustomLevel {
+
+                    /**
+                     * Constructs a new CustomLevel.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.ICustomLevel);
+
+                    /** CustomLevel expr. */
+                    public expr?: (google.type.IExpr|null);
+
+                    /**
+                     * Creates a new CustomLevel instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns CustomLevel instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.ICustomLevel): google.identity.accesscontextmanager.v1.CustomLevel;
+
+                    /**
+                     * Encodes the specified CustomLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.CustomLevel.verify|verify} messages.
+                     * @param message CustomLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.ICustomLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified CustomLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.CustomLevel.verify|verify} messages.
+                     * @param message CustomLevel message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.ICustomLevel, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a CustomLevel message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns CustomLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.CustomLevel;
+
+                    /**
+                     * Decodes a CustomLevel message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns CustomLevel
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.CustomLevel;
+
+                    /**
+                     * Verifies a CustomLevel message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a CustomLevel message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns CustomLevel
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.CustomLevel;
+
+                    /**
+                     * Creates a plain object from a CustomLevel message. Also converts values to other types if specified.
+                     * @param message CustomLevel
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.CustomLevel, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this CustomLevel to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a DevicePolicy. */
+                interface IDevicePolicy {
+
+                    /** DevicePolicy requireScreenlock */
+                    requireScreenlock?: (boolean|null);
+
+                    /** DevicePolicy allowedEncryptionStatuses */
+                    allowedEncryptionStatuses?: (google.identity.accesscontextmanager.type.DeviceEncryptionStatus[]|null);
+
+                    /** DevicePolicy osConstraints */
+                    osConstraints?: (google.identity.accesscontextmanager.v1.IOsConstraint[]|null);
+
+                    /** DevicePolicy allowedDeviceManagementLevels */
+                    allowedDeviceManagementLevels?: (google.identity.accesscontextmanager.type.DeviceManagementLevel[]|null);
+
+                    /** DevicePolicy requireAdminApproval */
+                    requireAdminApproval?: (boolean|null);
+
+                    /** DevicePolicy requireCorpOwned */
+                    requireCorpOwned?: (boolean|null);
+                }
+
+                /** Represents a DevicePolicy. */
+                class DevicePolicy implements IDevicePolicy {
+
+                    /**
+                     * Constructs a new DevicePolicy.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IDevicePolicy);
+
+                    /** DevicePolicy requireScreenlock. */
+                    public requireScreenlock: boolean;
+
+                    /** DevicePolicy allowedEncryptionStatuses. */
+                    public allowedEncryptionStatuses: google.identity.accesscontextmanager.type.DeviceEncryptionStatus[];
+
+                    /** DevicePolicy osConstraints. */
+                    public osConstraints: google.identity.accesscontextmanager.v1.IOsConstraint[];
+
+                    /** DevicePolicy allowedDeviceManagementLevels. */
+                    public allowedDeviceManagementLevels: google.identity.accesscontextmanager.type.DeviceManagementLevel[];
+
+                    /** DevicePolicy requireAdminApproval. */
+                    public requireAdminApproval: boolean;
+
+                    /** DevicePolicy requireCorpOwned. */
+                    public requireCorpOwned: boolean;
+
+                    /**
+                     * Creates a new DevicePolicy instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns DevicePolicy instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IDevicePolicy): google.identity.accesscontextmanager.v1.DevicePolicy;
+
+                    /**
+                     * Encodes the specified DevicePolicy message. Does not implicitly {@link google.identity.accesscontextmanager.v1.DevicePolicy.verify|verify} messages.
+                     * @param message DevicePolicy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IDevicePolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified DevicePolicy message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.DevicePolicy.verify|verify} messages.
+                     * @param message DevicePolicy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IDevicePolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a DevicePolicy message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns DevicePolicy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.DevicePolicy;
+
+                    /**
+                     * Decodes a DevicePolicy message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns DevicePolicy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.DevicePolicy;
+
+                    /**
+                     * Verifies a DevicePolicy message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a DevicePolicy message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns DevicePolicy
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.DevicePolicy;
+
+                    /**
+                     * Creates a plain object from a DevicePolicy message. Also converts values to other types if specified.
+                     * @param message DevicePolicy
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.DevicePolicy, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this DevicePolicy to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of an OsConstraint. */
+                interface IOsConstraint {
+
+                    /** OsConstraint osType */
+                    osType?: (google.identity.accesscontextmanager.type.OsType|keyof typeof google.identity.accesscontextmanager.type.OsType|null);
+
+                    /** OsConstraint minimumVersion */
+                    minimumVersion?: (string|null);
+
+                    /** OsConstraint requireVerifiedChromeOs */
+                    requireVerifiedChromeOs?: (boolean|null);
+                }
+
+                /** Represents an OsConstraint. */
+                class OsConstraint implements IOsConstraint {
+
+                    /**
+                     * Constructs a new OsConstraint.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IOsConstraint);
+
+                    /** OsConstraint osType. */
+                    public osType: (google.identity.accesscontextmanager.type.OsType|keyof typeof google.identity.accesscontextmanager.type.OsType);
+
+                    /** OsConstraint minimumVersion. */
+                    public minimumVersion: string;
+
+                    /** OsConstraint requireVerifiedChromeOs. */
+                    public requireVerifiedChromeOs: boolean;
+
+                    /**
+                     * Creates a new OsConstraint instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns OsConstraint instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IOsConstraint): google.identity.accesscontextmanager.v1.OsConstraint;
+
+                    /**
+                     * Encodes the specified OsConstraint message. Does not implicitly {@link google.identity.accesscontextmanager.v1.OsConstraint.verify|verify} messages.
+                     * @param message OsConstraint message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IOsConstraint, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified OsConstraint message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.OsConstraint.verify|verify} messages.
+                     * @param message OsConstraint message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IOsConstraint, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes an OsConstraint message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns OsConstraint
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.OsConstraint;
+
+                    /**
+                     * Decodes an OsConstraint message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns OsConstraint
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.OsConstraint;
+
+                    /**
+                     * Verifies an OsConstraint message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an OsConstraint message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns OsConstraint
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.OsConstraint;
+
+                    /**
+                     * Creates a plain object from an OsConstraint message. Also converts values to other types if specified.
+                     * @param message OsConstraint
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.OsConstraint, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this OsConstraint to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of an AccessPolicy. */
+                interface IAccessPolicy {
+
+                    /** AccessPolicy name */
+                    name?: (string|null);
+
+                    /** AccessPolicy parent */
+                    parent?: (string|null);
+
+                    /** AccessPolicy title */
+                    title?: (string|null);
+
+                    /** AccessPolicy createTime */
+                    createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessPolicy updateTime */
+                    updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessPolicy etag */
+                    etag?: (string|null);
+                }
+
+                /** Represents an AccessPolicy. */
+                class AccessPolicy implements IAccessPolicy {
+
+                    /**
+                     * Constructs a new AccessPolicy.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IAccessPolicy);
+
+                    /** AccessPolicy name. */
+                    public name: string;
+
+                    /** AccessPolicy parent. */
+                    public parent: string;
+
+                    /** AccessPolicy title. */
+                    public title: string;
+
+                    /** AccessPolicy createTime. */
+                    public createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessPolicy updateTime. */
+                    public updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** AccessPolicy etag. */
+                    public etag: string;
+
+                    /**
+                     * Creates a new AccessPolicy instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns AccessPolicy instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IAccessPolicy): google.identity.accesscontextmanager.v1.AccessPolicy;
+
+                    /**
+                     * Encodes the specified AccessPolicy message. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessPolicy.verify|verify} messages.
+                     * @param message AccessPolicy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IAccessPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified AccessPolicy message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessPolicy.verify|verify} messages.
+                     * @param message AccessPolicy message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IAccessPolicy, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes an AccessPolicy message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns AccessPolicy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.AccessPolicy;
+
+                    /**
+                     * Decodes an AccessPolicy message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns AccessPolicy
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.AccessPolicy;
+
+                    /**
+                     * Verifies an AccessPolicy message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates an AccessPolicy message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns AccessPolicy
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.AccessPolicy;
+
+                    /**
+                     * Creates a plain object from an AccessPolicy message. Also converts values to other types if specified.
+                     * @param message AccessPolicy
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.AccessPolicy, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this AccessPolicy to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                /** Properties of a ServicePerimeter. */
+                interface IServicePerimeter {
+
+                    /** ServicePerimeter name */
+                    name?: (string|null);
+
+                    /** ServicePerimeter title */
+                    title?: (string|null);
+
+                    /** ServicePerimeter description */
+                    description?: (string|null);
+
+                    /** ServicePerimeter createTime */
+                    createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** ServicePerimeter updateTime */
+                    updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** ServicePerimeter perimeterType */
+                    perimeterType?: (google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType|keyof typeof google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType|null);
+
+                    /** ServicePerimeter status */
+                    status?: (google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null);
+
+                    /** ServicePerimeter spec */
+                    spec?: (google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null);
+
+                    /** ServicePerimeter useExplicitDryRunSpec */
+                    useExplicitDryRunSpec?: (boolean|null);
+                }
+
+                /** Represents a ServicePerimeter. */
+                class ServicePerimeter implements IServicePerimeter {
+
+                    /**
+                     * Constructs a new ServicePerimeter.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IServicePerimeter);
+
+                    /** ServicePerimeter name. */
+                    public name: string;
+
+                    /** ServicePerimeter title. */
+                    public title: string;
+
+                    /** ServicePerimeter description. */
+                    public description: string;
+
+                    /** ServicePerimeter createTime. */
+                    public createTime?: (google.protobuf.ITimestamp|null);
+
+                    /** ServicePerimeter updateTime. */
+                    public updateTime?: (google.protobuf.ITimestamp|null);
+
+                    /** ServicePerimeter perimeterType. */
+                    public perimeterType: (google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType|keyof typeof google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType);
+
+                    /** ServicePerimeter status. */
+                    public status?: (google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null);
+
+                    /** ServicePerimeter spec. */
+                    public spec?: (google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null);
+
+                    /** ServicePerimeter useExplicitDryRunSpec. */
+                    public useExplicitDryRunSpec: boolean;
+
+                    /**
+                     * Creates a new ServicePerimeter instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns ServicePerimeter instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IServicePerimeter): google.identity.accesscontextmanager.v1.ServicePerimeter;
+
+                    /**
+                     * Encodes the specified ServicePerimeter message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeter.verify|verify} messages.
+                     * @param message ServicePerimeter message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IServicePerimeter, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified ServicePerimeter message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeter.verify|verify} messages.
+                     * @param message ServicePerimeter message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IServicePerimeter, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a ServicePerimeter message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns ServicePerimeter
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.ServicePerimeter;
+
+                    /**
+                     * Decodes a ServicePerimeter message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns ServicePerimeter
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.ServicePerimeter;
+
+                    /**
+                     * Verifies a ServicePerimeter message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a ServicePerimeter message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns ServicePerimeter
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.ServicePerimeter;
+
+                    /**
+                     * Creates a plain object from a ServicePerimeter message. Also converts values to other types if specified.
+                     * @param message ServicePerimeter
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.ServicePerimeter, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this ServicePerimeter to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                namespace ServicePerimeter {
+
+                    /** PerimeterType enum. */
+                    enum PerimeterType {
+                        PERIMETER_TYPE_REGULAR = 0,
+                        PERIMETER_TYPE_BRIDGE = 1
+                    }
+                }
+
+                /** Properties of a ServicePerimeterConfig. */
+                interface IServicePerimeterConfig {
+
+                    /** ServicePerimeterConfig resources */
+                    resources?: (string[]|null);
+
+                    /** ServicePerimeterConfig accessLevels */
+                    accessLevels?: (string[]|null);
+
+                    /** ServicePerimeterConfig restrictedServices */
+                    restrictedServices?: (string[]|null);
+
+                    /** ServicePerimeterConfig vpcAccessibleServices */
+                    vpcAccessibleServices?: (google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices|null);
+                }
+
+                /** Represents a ServicePerimeterConfig. */
+                class ServicePerimeterConfig implements IServicePerimeterConfig {
+
+                    /**
+                     * Constructs a new ServicePerimeterConfig.
+                     * @param [properties] Properties to set
+                     */
+                    constructor(properties?: google.identity.accesscontextmanager.v1.IServicePerimeterConfig);
+
+                    /** ServicePerimeterConfig resources. */
+                    public resources: string[];
+
+                    /** ServicePerimeterConfig accessLevels. */
+                    public accessLevels: string[];
+
+                    /** ServicePerimeterConfig restrictedServices. */
+                    public restrictedServices: string[];
+
+                    /** ServicePerimeterConfig vpcAccessibleServices. */
+                    public vpcAccessibleServices?: (google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices|null);
+
+                    /**
+                     * Creates a new ServicePerimeterConfig instance using the specified properties.
+                     * @param [properties] Properties to set
+                     * @returns ServicePerimeterConfig instance
+                     */
+                    public static create(properties?: google.identity.accesscontextmanager.v1.IServicePerimeterConfig): google.identity.accesscontextmanager.v1.ServicePerimeterConfig;
+
+                    /**
+                     * Encodes the specified ServicePerimeterConfig message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify|verify} messages.
+                     * @param message ServicePerimeterConfig message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encode(message: google.identity.accesscontextmanager.v1.IServicePerimeterConfig, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Encodes the specified ServicePerimeterConfig message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify|verify} messages.
+                     * @param message ServicePerimeterConfig message or plain object to encode
+                     * @param [writer] Writer to encode to
+                     * @returns Writer
+                     */
+                    public static encodeDelimited(message: google.identity.accesscontextmanager.v1.IServicePerimeterConfig, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                    /**
+                     * Decodes a ServicePerimeterConfig message from the specified reader or buffer.
+                     * @param reader Reader or buffer to decode from
+                     * @param [length] Message length if known beforehand
+                     * @returns ServicePerimeterConfig
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.ServicePerimeterConfig;
+
+                    /**
+                     * Decodes a ServicePerimeterConfig message from the specified reader or buffer, length delimited.
+                     * @param reader Reader or buffer to decode from
+                     * @returns ServicePerimeterConfig
+                     * @throws {Error} If the payload is not a reader or valid buffer
+                     * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                     */
+                    public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.ServicePerimeterConfig;
+
+                    /**
+                     * Verifies a ServicePerimeterConfig message.
+                     * @param message Plain object to verify
+                     * @returns `null` if valid, otherwise the reason why it is not
+                     */
+                    public static verify(message: { [k: string]: any }): (string|null);
+
+                    /**
+                     * Creates a ServicePerimeterConfig message from a plain object. Also converts values to their respective internal types.
+                     * @param object Plain object
+                     * @returns ServicePerimeterConfig
+                     */
+                    public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.ServicePerimeterConfig;
+
+                    /**
+                     * Creates a plain object from a ServicePerimeterConfig message. Also converts values to other types if specified.
+                     * @param message ServicePerimeterConfig
+                     * @param [options] Conversion options
+                     * @returns Plain object
+                     */
+                    public static toObject(message: google.identity.accesscontextmanager.v1.ServicePerimeterConfig, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                    /**
+                     * Converts this ServicePerimeterConfig to JSON.
+                     * @returns JSON object
+                     */
+                    public toJSON(): { [k: string]: any };
+                }
+
+                namespace ServicePerimeterConfig {
+
+                    /** Properties of a VpcAccessibleServices. */
+                    interface IVpcAccessibleServices {
+
+                        /** VpcAccessibleServices enableRestriction */
+                        enableRestriction?: (boolean|null);
+
+                        /** VpcAccessibleServices allowedServices */
+                        allowedServices?: (string[]|null);
+                    }
+
+                    /** Represents a VpcAccessibleServices. */
+                    class VpcAccessibleServices implements IVpcAccessibleServices {
+
+                        /**
+                         * Constructs a new VpcAccessibleServices.
+                         * @param [properties] Properties to set
+                         */
+                        constructor(properties?: google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices);
+
+                        /** VpcAccessibleServices enableRestriction. */
+                        public enableRestriction: boolean;
+
+                        /** VpcAccessibleServices allowedServices. */
+                        public allowedServices: string[];
+
+                        /**
+                         * Creates a new VpcAccessibleServices instance using the specified properties.
+                         * @param [properties] Properties to set
+                         * @returns VpcAccessibleServices instance
+                         */
+                        public static create(properties?: google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices): google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices;
+
+                        /**
+                         * Encodes the specified VpcAccessibleServices message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.verify|verify} messages.
+                         * @param message VpcAccessibleServices message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encode(message: google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Encodes the specified VpcAccessibleServices message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.verify|verify} messages.
+                         * @param message VpcAccessibleServices message or plain object to encode
+                         * @param [writer] Writer to encode to
+                         * @returns Writer
+                         */
+                        public static encodeDelimited(message: google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices, writer?: $protobuf.Writer): $protobuf.Writer;
+
+                        /**
+                         * Decodes a VpcAccessibleServices message from the specified reader or buffer.
+                         * @param reader Reader or buffer to decode from
+                         * @param [length] Message length if known beforehand
+                         * @returns VpcAccessibleServices
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices;
+
+                        /**
+                         * Decodes a VpcAccessibleServices message from the specified reader or buffer, length delimited.
+                         * @param reader Reader or buffer to decode from
+                         * @returns VpcAccessibleServices
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices;
+
+                        /**
+                         * Verifies a VpcAccessibleServices message.
+                         * @param message Plain object to verify
+                         * @returns `null` if valid, otherwise the reason why it is not
+                         */
+                        public static verify(message: { [k: string]: any }): (string|null);
+
+                        /**
+                         * Creates a VpcAccessibleServices message from a plain object. Also converts values to their respective internal types.
+                         * @param object Plain object
+                         * @returns VpcAccessibleServices
+                         */
+                        public static fromObject(object: { [k: string]: any }): google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices;
+
+                        /**
+                         * Creates a plain object from a VpcAccessibleServices message. Also converts values to other types if specified.
+                         * @param message VpcAccessibleServices
+                         * @param [options] Conversion options
+                         * @returns Plain object
+                         */
+                        public static toObject(message: google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices, options?: $protobuf.IConversionOptions): { [k: string]: any };
+
+                        /**
+                         * Converts this VpcAccessibleServices to JSON.
+                         * @returns JSON object
+                         */
+                        public toJSON(): { [k: string]: any };
+                    }
+                }
+            }
+
+            /** Namespace type. */
+            namespace type {
+
+                /** DeviceEncryptionStatus enum. */
+                enum DeviceEncryptionStatus {
+                    ENCRYPTION_UNSPECIFIED = 0,
+                    ENCRYPTION_UNSUPPORTED = 1,
+                    UNENCRYPTED = 2,
+                    ENCRYPTED = 3
+                }
+
+                /** OsType enum. */
+                enum OsType {
+                    OS_UNSPECIFIED = 0,
+                    DESKTOP_MAC = 1,
+                    DESKTOP_WINDOWS = 2,
+                    DESKTOP_LINUX = 3,
+                    DESKTOP_CHROME_OS = 6,
+                    ANDROID = 4,
+                    IOS = 5
+                }
+
+                /** DeviceManagementLevel enum. */
+                enum DeviceManagementLevel {
+                    MANAGEMENT_UNSPECIFIED = 0,
+                    NONE = 1,
+                    BASIC = 2,
+                    COMPLETE = 3
+                }
+            }
         }
     }
 

--- a/protos/protos.js
+++ b/protos/protos.js
@@ -28,7 +28,7 @@
     var $Reader = $protobuf.Reader, $Writer = $protobuf.Writer, $util = $protobuf.util;
     
     // Exported root namespace
-    var $root = $protobuf.roots["default"] || ($protobuf.roots["default"] = {});
+    var $root = $protobuf.roots._google_cloud_asset_2_2_0_protos || ($protobuf.roots._google_cloud_asset_2_2_0_protos = {});
     
     $root.google = (function() {
     
@@ -3518,26 +3518,6 @@
                         return PubsubDestination;
                     })();
     
-                    /**
-                     * ContentType enum.
-                     * @name google.cloud.asset.v1.ContentType
-                     * @enum {string}
-                     * @property {number} CONTENT_TYPE_UNSPECIFIED=0 CONTENT_TYPE_UNSPECIFIED value
-                     * @property {number} RESOURCE=1 RESOURCE value
-                     * @property {number} IAM_POLICY=2 IAM_POLICY value
-                     * @property {number} ORG_POLICY=4 ORG_POLICY value
-                     * @property {number} ACCESS_POLICY=5 ACCESS_POLICY value
-                     */
-                    v1.ContentType = (function() {
-                        var valuesById = {}, values = Object.create(valuesById);
-                        values[valuesById[0] = "CONTENT_TYPE_UNSPECIFIED"] = 0;
-                        values[valuesById[1] = "RESOURCE"] = 1;
-                        values[valuesById[2] = "IAM_POLICY"] = 2;
-                        values[valuesById[4] = "ORG_POLICY"] = 4;
-                        values[valuesById[5] = "ACCESS_POLICY"] = 5;
-                        return values;
-                    })();
-    
                     v1.FeedOutputConfig = (function() {
     
                         /**
@@ -4092,6 +4072,26 @@
                         return Feed;
                     })();
     
+                    /**
+                     * ContentType enum.
+                     * @name google.cloud.asset.v1.ContentType
+                     * @enum {string}
+                     * @property {number} CONTENT_TYPE_UNSPECIFIED=0 CONTENT_TYPE_UNSPECIFIED value
+                     * @property {number} RESOURCE=1 RESOURCE value
+                     * @property {number} IAM_POLICY=2 IAM_POLICY value
+                     * @property {number} ORG_POLICY=4 ORG_POLICY value
+                     * @property {number} ACCESS_POLICY=5 ACCESS_POLICY value
+                     */
+                    v1.ContentType = (function() {
+                        var valuesById = {}, values = Object.create(valuesById);
+                        values[valuesById[0] = "CONTENT_TYPE_UNSPECIFIED"] = 0;
+                        values[valuesById[1] = "RESOURCE"] = 1;
+                        values[valuesById[2] = "IAM_POLICY"] = 2;
+                        values[valuesById[4] = "ORG_POLICY"] = 4;
+                        values[valuesById[5] = "ACCESS_POLICY"] = 5;
+                        return values;
+                    })();
+    
                     v1.TemporalAsset = (function() {
     
                         /**
@@ -4564,6 +4564,10 @@
                          * @property {string|null} [assetType] Asset assetType
                          * @property {google.cloud.asset.v1.IResource|null} [resource] Asset resource
                          * @property {google.iam.v1.IPolicy|null} [iamPolicy] Asset iamPolicy
+                         * @property {Array.<google.cloud.orgpolicy.v1.IPolicy>|null} [orgPolicy] Asset orgPolicy
+                         * @property {google.identity.accesscontextmanager.v1.IAccessPolicy|null} [accessPolicy] Asset accessPolicy
+                         * @property {google.identity.accesscontextmanager.v1.IAccessLevel|null} [accessLevel] Asset accessLevel
+                         * @property {google.identity.accesscontextmanager.v1.IServicePerimeter|null} [servicePerimeter] Asset servicePerimeter
                          * @property {Array.<string>|null} [ancestors] Asset ancestors
                          */
     
@@ -4576,6 +4580,7 @@
                          * @param {google.cloud.asset.v1.IAsset=} [properties] Properties to set
                          */
                         function Asset(properties) {
+                            this.orgPolicy = [];
                             this.ancestors = [];
                             if (properties)
                                 for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
@@ -4616,12 +4621,58 @@
                         Asset.prototype.iamPolicy = null;
     
                         /**
+                         * Asset orgPolicy.
+                         * @member {Array.<google.cloud.orgpolicy.v1.IPolicy>} orgPolicy
+                         * @memberof google.cloud.asset.v1.Asset
+                         * @instance
+                         */
+                        Asset.prototype.orgPolicy = $util.emptyArray;
+    
+                        /**
+                         * Asset accessPolicy.
+                         * @member {google.identity.accesscontextmanager.v1.IAccessPolicy|null|undefined} accessPolicy
+                         * @memberof google.cloud.asset.v1.Asset
+                         * @instance
+                         */
+                        Asset.prototype.accessPolicy = null;
+    
+                        /**
+                         * Asset accessLevel.
+                         * @member {google.identity.accesscontextmanager.v1.IAccessLevel|null|undefined} accessLevel
+                         * @memberof google.cloud.asset.v1.Asset
+                         * @instance
+                         */
+                        Asset.prototype.accessLevel = null;
+    
+                        /**
+                         * Asset servicePerimeter.
+                         * @member {google.identity.accesscontextmanager.v1.IServicePerimeter|null|undefined} servicePerimeter
+                         * @memberof google.cloud.asset.v1.Asset
+                         * @instance
+                         */
+                        Asset.prototype.servicePerimeter = null;
+    
+                        /**
                          * Asset ancestors.
                          * @member {Array.<string>} ancestors
                          * @memberof google.cloud.asset.v1.Asset
                          * @instance
                          */
                         Asset.prototype.ancestors = $util.emptyArray;
+    
+                        // OneOf field names bound to virtual getters and setters
+                        var $oneOfFields;
+    
+                        /**
+                         * Asset accessContextPolicy.
+                         * @member {"accessPolicy"|"accessLevel"|"servicePerimeter"|undefined} accessContextPolicy
+                         * @memberof google.cloud.asset.v1.Asset
+                         * @instance
+                         */
+                        Object.defineProperty(Asset.prototype, "accessContextPolicy", {
+                            get: $util.oneOfGetter($oneOfFields = ["accessPolicy", "accessLevel", "servicePerimeter"]),
+                            set: $util.oneOfSetter($oneOfFields)
+                        });
     
                         /**
                          * Creates a new Asset instance using the specified properties.
@@ -4655,6 +4706,15 @@
                                 $root.google.cloud.asset.v1.Resource.encode(message.resource, writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
                             if (message.iamPolicy != null && message.hasOwnProperty("iamPolicy"))
                                 $root.google.iam.v1.Policy.encode(message.iamPolicy, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                            if (message.orgPolicy != null && message.orgPolicy.length)
+                                for (var i = 0; i < message.orgPolicy.length; ++i)
+                                    $root.google.cloud.orgpolicy.v1.Policy.encode(message.orgPolicy[i], writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                            if (message.accessPolicy != null && message.hasOwnProperty("accessPolicy"))
+                                $root.google.identity.accesscontextmanager.v1.AccessPolicy.encode(message.accessPolicy, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                            if (message.accessLevel != null && message.hasOwnProperty("accessLevel"))
+                                $root.google.identity.accesscontextmanager.v1.AccessLevel.encode(message.accessLevel, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                            if (message.servicePerimeter != null && message.hasOwnProperty("servicePerimeter"))
+                                $root.google.identity.accesscontextmanager.v1.ServicePerimeter.encode(message.servicePerimeter, writer.uint32(/* id 9, wireType 2 =*/74).fork()).ldelim();
                             if (message.ancestors != null && message.ancestors.length)
                                 for (var i = 0; i < message.ancestors.length; ++i)
                                     writer.uint32(/* id 10, wireType 2 =*/82).string(message.ancestors[i]);
@@ -4704,6 +4764,20 @@
                                 case 4:
                                     message.iamPolicy = $root.google.iam.v1.Policy.decode(reader, reader.uint32());
                                     break;
+                                case 6:
+                                    if (!(message.orgPolicy && message.orgPolicy.length))
+                                        message.orgPolicy = [];
+                                    message.orgPolicy.push($root.google.cloud.orgpolicy.v1.Policy.decode(reader, reader.uint32()));
+                                    break;
+                                case 7:
+                                    message.accessPolicy = $root.google.identity.accesscontextmanager.v1.AccessPolicy.decode(reader, reader.uint32());
+                                    break;
+                                case 8:
+                                    message.accessLevel = $root.google.identity.accesscontextmanager.v1.AccessLevel.decode(reader, reader.uint32());
+                                    break;
+                                case 9:
+                                    message.servicePerimeter = $root.google.identity.accesscontextmanager.v1.ServicePerimeter.decode(reader, reader.uint32());
+                                    break;
                                 case 10:
                                     if (!(message.ancestors && message.ancestors.length))
                                         message.ancestors = [];
@@ -4744,6 +4818,7 @@
                         Asset.verify = function verify(message) {
                             if (typeof message !== "object" || message === null)
                                 return "object expected";
+                            var properties = {};
                             if (message.name != null && message.hasOwnProperty("name"))
                                 if (!$util.isString(message.name))
                                     return "name: string expected";
@@ -4759,6 +4834,43 @@
                                 var error = $root.google.iam.v1.Policy.verify(message.iamPolicy);
                                 if (error)
                                     return "iamPolicy." + error;
+                            }
+                            if (message.orgPolicy != null && message.hasOwnProperty("orgPolicy")) {
+                                if (!Array.isArray(message.orgPolicy))
+                                    return "orgPolicy: array expected";
+                                for (var i = 0; i < message.orgPolicy.length; ++i) {
+                                    var error = $root.google.cloud.orgpolicy.v1.Policy.verify(message.orgPolicy[i]);
+                                    if (error)
+                                        return "orgPolicy." + error;
+                                }
+                            }
+                            if (message.accessPolicy != null && message.hasOwnProperty("accessPolicy")) {
+                                properties.accessContextPolicy = 1;
+                                {
+                                    var error = $root.google.identity.accesscontextmanager.v1.AccessPolicy.verify(message.accessPolicy);
+                                    if (error)
+                                        return "accessPolicy." + error;
+                                }
+                            }
+                            if (message.accessLevel != null && message.hasOwnProperty("accessLevel")) {
+                                if (properties.accessContextPolicy === 1)
+                                    return "accessContextPolicy: multiple values";
+                                properties.accessContextPolicy = 1;
+                                {
+                                    var error = $root.google.identity.accesscontextmanager.v1.AccessLevel.verify(message.accessLevel);
+                                    if (error)
+                                        return "accessLevel." + error;
+                                }
+                            }
+                            if (message.servicePerimeter != null && message.hasOwnProperty("servicePerimeter")) {
+                                if (properties.accessContextPolicy === 1)
+                                    return "accessContextPolicy: multiple values";
+                                properties.accessContextPolicy = 1;
+                                {
+                                    var error = $root.google.identity.accesscontextmanager.v1.ServicePerimeter.verify(message.servicePerimeter);
+                                    if (error)
+                                        return "servicePerimeter." + error;
+                                }
                             }
                             if (message.ancestors != null && message.hasOwnProperty("ancestors")) {
                                 if (!Array.isArray(message.ancestors))
@@ -4796,6 +4908,31 @@
                                     throw TypeError(".google.cloud.asset.v1.Asset.iamPolicy: object expected");
                                 message.iamPolicy = $root.google.iam.v1.Policy.fromObject(object.iamPolicy);
                             }
+                            if (object.orgPolicy) {
+                                if (!Array.isArray(object.orgPolicy))
+                                    throw TypeError(".google.cloud.asset.v1.Asset.orgPolicy: array expected");
+                                message.orgPolicy = [];
+                                for (var i = 0; i < object.orgPolicy.length; ++i) {
+                                    if (typeof object.orgPolicy[i] !== "object")
+                                        throw TypeError(".google.cloud.asset.v1.Asset.orgPolicy: object expected");
+                                    message.orgPolicy[i] = $root.google.cloud.orgpolicy.v1.Policy.fromObject(object.orgPolicy[i]);
+                                }
+                            }
+                            if (object.accessPolicy != null) {
+                                if (typeof object.accessPolicy !== "object")
+                                    throw TypeError(".google.cloud.asset.v1.Asset.accessPolicy: object expected");
+                                message.accessPolicy = $root.google.identity.accesscontextmanager.v1.AccessPolicy.fromObject(object.accessPolicy);
+                            }
+                            if (object.accessLevel != null) {
+                                if (typeof object.accessLevel !== "object")
+                                    throw TypeError(".google.cloud.asset.v1.Asset.accessLevel: object expected");
+                                message.accessLevel = $root.google.identity.accesscontextmanager.v1.AccessLevel.fromObject(object.accessLevel);
+                            }
+                            if (object.servicePerimeter != null) {
+                                if (typeof object.servicePerimeter !== "object")
+                                    throw TypeError(".google.cloud.asset.v1.Asset.servicePerimeter: object expected");
+                                message.servicePerimeter = $root.google.identity.accesscontextmanager.v1.ServicePerimeter.fromObject(object.servicePerimeter);
+                            }
                             if (object.ancestors) {
                                 if (!Array.isArray(object.ancestors))
                                     throw TypeError(".google.cloud.asset.v1.Asset.ancestors: array expected");
@@ -4819,8 +4956,10 @@
                             if (!options)
                                 options = {};
                             var object = {};
-                            if (options.arrays || options.defaults)
+                            if (options.arrays || options.defaults) {
+                                object.orgPolicy = [];
                                 object.ancestors = [];
+                            }
                             if (options.defaults) {
                                 object.name = "";
                                 object.assetType = "";
@@ -4835,6 +4974,26 @@
                                 object.resource = $root.google.cloud.asset.v1.Resource.toObject(message.resource, options);
                             if (message.iamPolicy != null && message.hasOwnProperty("iamPolicy"))
                                 object.iamPolicy = $root.google.iam.v1.Policy.toObject(message.iamPolicy, options);
+                            if (message.orgPolicy && message.orgPolicy.length) {
+                                object.orgPolicy = [];
+                                for (var j = 0; j < message.orgPolicy.length; ++j)
+                                    object.orgPolicy[j] = $root.google.cloud.orgpolicy.v1.Policy.toObject(message.orgPolicy[j], options);
+                            }
+                            if (message.accessPolicy != null && message.hasOwnProperty("accessPolicy")) {
+                                object.accessPolicy = $root.google.identity.accesscontextmanager.v1.AccessPolicy.toObject(message.accessPolicy, options);
+                                if (options.oneofs)
+                                    object.accessContextPolicy = "accessPolicy";
+                            }
+                            if (message.accessLevel != null && message.hasOwnProperty("accessLevel")) {
+                                object.accessLevel = $root.google.identity.accesscontextmanager.v1.AccessLevel.toObject(message.accessLevel, options);
+                                if (options.oneofs)
+                                    object.accessContextPolicy = "accessLevel";
+                            }
+                            if (message.servicePerimeter != null && message.hasOwnProperty("servicePerimeter")) {
+                                object.servicePerimeter = $root.google.identity.accesscontextmanager.v1.ServicePerimeter.toObject(message.servicePerimeter, options);
+                                if (options.oneofs)
+                                    object.accessContextPolicy = "servicePerimeter";
+                            }
                             if (message.ancestors && message.ancestors.length) {
                                 object.ancestors = [];
                                 for (var j = 0; j < message.ancestors.length; ++j)
@@ -18448,6 +18607,1104 @@
                 return asset;
             })();
     
+            cloud.orgpolicy = (function() {
+    
+                /**
+                 * Namespace orgpolicy.
+                 * @memberof google.cloud
+                 * @namespace
+                 */
+                var orgpolicy = {};
+    
+                orgpolicy.v1 = (function() {
+    
+                    /**
+                     * Namespace v1.
+                     * @memberof google.cloud.orgpolicy
+                     * @namespace
+                     */
+                    var v1 = {};
+    
+                    v1.Policy = (function() {
+    
+                        /**
+                         * Properties of a Policy.
+                         * @memberof google.cloud.orgpolicy.v1
+                         * @interface IPolicy
+                         * @property {number|null} [version] Policy version
+                         * @property {string|null} [constraint] Policy constraint
+                         * @property {Uint8Array|null} [etag] Policy etag
+                         * @property {google.protobuf.ITimestamp|null} [updateTime] Policy updateTime
+                         * @property {google.cloud.orgpolicy.v1.Policy.IListPolicy|null} [listPolicy] Policy listPolicy
+                         * @property {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy|null} [booleanPolicy] Policy booleanPolicy
+                         * @property {google.cloud.orgpolicy.v1.Policy.IRestoreDefault|null} [restoreDefault] Policy restoreDefault
+                         */
+    
+                        /**
+                         * Constructs a new Policy.
+                         * @memberof google.cloud.orgpolicy.v1
+                         * @classdesc Represents a Policy.
+                         * @implements IPolicy
+                         * @constructor
+                         * @param {google.cloud.orgpolicy.v1.IPolicy=} [properties] Properties to set
+                         */
+                        function Policy(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * Policy version.
+                         * @member {number} version
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.version = 0;
+    
+                        /**
+                         * Policy constraint.
+                         * @member {string} constraint
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.constraint = "";
+    
+                        /**
+                         * Policy etag.
+                         * @member {Uint8Array} etag
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.etag = $util.newBuffer([]);
+    
+                        /**
+                         * Policy updateTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} updateTime
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.updateTime = null;
+    
+                        /**
+                         * Policy listPolicy.
+                         * @member {google.cloud.orgpolicy.v1.Policy.IListPolicy|null|undefined} listPolicy
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.listPolicy = null;
+    
+                        /**
+                         * Policy booleanPolicy.
+                         * @member {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy|null|undefined} booleanPolicy
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.booleanPolicy = null;
+    
+                        /**
+                         * Policy restoreDefault.
+                         * @member {google.cloud.orgpolicy.v1.Policy.IRestoreDefault|null|undefined} restoreDefault
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Policy.prototype.restoreDefault = null;
+    
+                        // OneOf field names bound to virtual getters and setters
+                        var $oneOfFields;
+    
+                        /**
+                         * Policy policyType.
+                         * @member {"listPolicy"|"booleanPolicy"|"restoreDefault"|undefined} policyType
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         */
+                        Object.defineProperty(Policy.prototype, "policyType", {
+                            get: $util.oneOfGetter($oneOfFields = ["listPolicy", "booleanPolicy", "restoreDefault"]),
+                            set: $util.oneOfSetter($oneOfFields)
+                        });
+    
+                        /**
+                         * Creates a new Policy instance using the specified properties.
+                         * @function create
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {google.cloud.orgpolicy.v1.IPolicy=} [properties] Properties to set
+                         * @returns {google.cloud.orgpolicy.v1.Policy} Policy instance
+                         */
+                        Policy.create = function create(properties) {
+                            return new Policy(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified Policy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {google.cloud.orgpolicy.v1.IPolicy} message Policy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        Policy.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.version != null && message.hasOwnProperty("version"))
+                                writer.uint32(/* id 1, wireType 0 =*/8).int32(message.version);
+                            if (message.constraint != null && message.hasOwnProperty("constraint"))
+                                writer.uint32(/* id 2, wireType 2 =*/18).string(message.constraint);
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                writer.uint32(/* id 3, wireType 2 =*/26).bytes(message.etag);
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                $root.google.protobuf.Timestamp.encode(message.updateTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                            if (message.listPolicy != null && message.hasOwnProperty("listPolicy"))
+                                $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.encode(message.listPolicy, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                            if (message.booleanPolicy != null && message.hasOwnProperty("booleanPolicy"))
+                                $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy.encode(message.booleanPolicy, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                            if (message.restoreDefault != null && message.hasOwnProperty("restoreDefault"))
+                                $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault.encode(message.restoreDefault, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified Policy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {google.cloud.orgpolicy.v1.IPolicy} message Policy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        Policy.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a Policy message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.cloud.orgpolicy.v1.Policy} Policy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        Policy.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.cloud.orgpolicy.v1.Policy();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.version = reader.int32();
+                                    break;
+                                case 2:
+                                    message.constraint = reader.string();
+                                    break;
+                                case 3:
+                                    message.etag = reader.bytes();
+                                    break;
+                                case 4:
+                                    message.updateTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 5:
+                                    message.listPolicy = $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.decode(reader, reader.uint32());
+                                    break;
+                                case 6:
+                                    message.booleanPolicy = $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy.decode(reader, reader.uint32());
+                                    break;
+                                case 7:
+                                    message.restoreDefault = $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a Policy message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.cloud.orgpolicy.v1.Policy} Policy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        Policy.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a Policy message.
+                         * @function verify
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        Policy.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            var properties = {};
+                            if (message.version != null && message.hasOwnProperty("version"))
+                                if (!$util.isInteger(message.version))
+                                    return "version: integer expected";
+                            if (message.constraint != null && message.hasOwnProperty("constraint"))
+                                if (!$util.isString(message.constraint))
+                                    return "constraint: string expected";
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                if (!(message.etag && typeof message.etag.length === "number" || $util.isString(message.etag)))
+                                    return "etag: buffer expected";
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.updateTime);
+                                if (error)
+                                    return "updateTime." + error;
+                            }
+                            if (message.listPolicy != null && message.hasOwnProperty("listPolicy")) {
+                                properties.policyType = 1;
+                                {
+                                    var error = $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.verify(message.listPolicy);
+                                    if (error)
+                                        return "listPolicy." + error;
+                                }
+                            }
+                            if (message.booleanPolicy != null && message.hasOwnProperty("booleanPolicy")) {
+                                if (properties.policyType === 1)
+                                    return "policyType: multiple values";
+                                properties.policyType = 1;
+                                {
+                                    var error = $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy.verify(message.booleanPolicy);
+                                    if (error)
+                                        return "booleanPolicy." + error;
+                                }
+                            }
+                            if (message.restoreDefault != null && message.hasOwnProperty("restoreDefault")) {
+                                if (properties.policyType === 1)
+                                    return "policyType: multiple values";
+                                properties.policyType = 1;
+                                {
+                                    var error = $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault.verify(message.restoreDefault);
+                                    if (error)
+                                        return "restoreDefault." + error;
+                                }
+                            }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a Policy message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.cloud.orgpolicy.v1.Policy} Policy
+                         */
+                        Policy.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.cloud.orgpolicy.v1.Policy)
+                                return object;
+                            var message = new $root.google.cloud.orgpolicy.v1.Policy();
+                            if (object.version != null)
+                                message.version = object.version | 0;
+                            if (object.constraint != null)
+                                message.constraint = String(object.constraint);
+                            if (object.etag != null)
+                                if (typeof object.etag === "string")
+                                    $util.base64.decode(object.etag, message.etag = $util.newBuffer($util.base64.length(object.etag)), 0);
+                                else if (object.etag.length)
+                                    message.etag = object.etag;
+                            if (object.updateTime != null) {
+                                if (typeof object.updateTime !== "object")
+                                    throw TypeError(".google.cloud.orgpolicy.v1.Policy.updateTime: object expected");
+                                message.updateTime = $root.google.protobuf.Timestamp.fromObject(object.updateTime);
+                            }
+                            if (object.listPolicy != null) {
+                                if (typeof object.listPolicy !== "object")
+                                    throw TypeError(".google.cloud.orgpolicy.v1.Policy.listPolicy: object expected");
+                                message.listPolicy = $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.fromObject(object.listPolicy);
+                            }
+                            if (object.booleanPolicy != null) {
+                                if (typeof object.booleanPolicy !== "object")
+                                    throw TypeError(".google.cloud.orgpolicy.v1.Policy.booleanPolicy: object expected");
+                                message.booleanPolicy = $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy.fromObject(object.booleanPolicy);
+                            }
+                            if (object.restoreDefault != null) {
+                                if (typeof object.restoreDefault !== "object")
+                                    throw TypeError(".google.cloud.orgpolicy.v1.Policy.restoreDefault: object expected");
+                                message.restoreDefault = $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault.fromObject(object.restoreDefault);
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a Policy message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @static
+                         * @param {google.cloud.orgpolicy.v1.Policy} message Policy
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        Policy.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults) {
+                                object.version = 0;
+                                object.constraint = "";
+                                if (options.bytes === String)
+                                    object.etag = "";
+                                else {
+                                    object.etag = [];
+                                    if (options.bytes !== Array)
+                                        object.etag = $util.newBuffer(object.etag);
+                                }
+                                object.updateTime = null;
+                            }
+                            if (message.version != null && message.hasOwnProperty("version"))
+                                object.version = message.version;
+                            if (message.constraint != null && message.hasOwnProperty("constraint"))
+                                object.constraint = message.constraint;
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                object.etag = options.bytes === String ? $util.base64.encode(message.etag, 0, message.etag.length) : options.bytes === Array ? Array.prototype.slice.call(message.etag) : message.etag;
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                object.updateTime = $root.google.protobuf.Timestamp.toObject(message.updateTime, options);
+                            if (message.listPolicy != null && message.hasOwnProperty("listPolicy")) {
+                                object.listPolicy = $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.toObject(message.listPolicy, options);
+                                if (options.oneofs)
+                                    object.policyType = "listPolicy";
+                            }
+                            if (message.booleanPolicy != null && message.hasOwnProperty("booleanPolicy")) {
+                                object.booleanPolicy = $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy.toObject(message.booleanPolicy, options);
+                                if (options.oneofs)
+                                    object.policyType = "booleanPolicy";
+                            }
+                            if (message.restoreDefault != null && message.hasOwnProperty("restoreDefault")) {
+                                object.restoreDefault = $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault.toObject(message.restoreDefault, options);
+                                if (options.oneofs)
+                                    object.policyType = "restoreDefault";
+                            }
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this Policy to JSON.
+                         * @function toJSON
+                         * @memberof google.cloud.orgpolicy.v1.Policy
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        Policy.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        Policy.ListPolicy = (function() {
+    
+                            /**
+                             * Properties of a ListPolicy.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @interface IListPolicy
+                             * @property {Array.<string>|null} [allowedValues] ListPolicy allowedValues
+                             * @property {Array.<string>|null} [deniedValues] ListPolicy deniedValues
+                             * @property {google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues|null} [allValues] ListPolicy allValues
+                             * @property {string|null} [suggestedValue] ListPolicy suggestedValue
+                             * @property {boolean|null} [inheritFromParent] ListPolicy inheritFromParent
+                             */
+    
+                            /**
+                             * Constructs a new ListPolicy.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @classdesc Represents a ListPolicy.
+                             * @implements IListPolicy
+                             * @constructor
+                             * @param {google.cloud.orgpolicy.v1.Policy.IListPolicy=} [properties] Properties to set
+                             */
+                            function ListPolicy(properties) {
+                                this.allowedValues = [];
+                                this.deniedValues = [];
+                                if (properties)
+                                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                        if (properties[keys[i]] != null)
+                                            this[keys[i]] = properties[keys[i]];
+                            }
+    
+                            /**
+                             * ListPolicy allowedValues.
+                             * @member {Array.<string>} allowedValues
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             */
+                            ListPolicy.prototype.allowedValues = $util.emptyArray;
+    
+                            /**
+                             * ListPolicy deniedValues.
+                             * @member {Array.<string>} deniedValues
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             */
+                            ListPolicy.prototype.deniedValues = $util.emptyArray;
+    
+                            /**
+                             * ListPolicy allValues.
+                             * @member {google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues} allValues
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             */
+                            ListPolicy.prototype.allValues = 0;
+    
+                            /**
+                             * ListPolicy suggestedValue.
+                             * @member {string} suggestedValue
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             */
+                            ListPolicy.prototype.suggestedValue = "";
+    
+                            /**
+                             * ListPolicy inheritFromParent.
+                             * @member {boolean} inheritFromParent
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             */
+                            ListPolicy.prototype.inheritFromParent = false;
+    
+                            /**
+                             * Creates a new ListPolicy instance using the specified properties.
+                             * @function create
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IListPolicy=} [properties] Properties to set
+                             * @returns {google.cloud.orgpolicy.v1.Policy.ListPolicy} ListPolicy instance
+                             */
+                            ListPolicy.create = function create(properties) {
+                                return new ListPolicy(properties);
+                            };
+    
+                            /**
+                             * Encodes the specified ListPolicy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.ListPolicy.verify|verify} messages.
+                             * @function encode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IListPolicy} message ListPolicy message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            ListPolicy.encode = function encode(message, writer) {
+                                if (!writer)
+                                    writer = $Writer.create();
+                                if (message.allowedValues != null && message.allowedValues.length)
+                                    for (var i = 0; i < message.allowedValues.length; ++i)
+                                        writer.uint32(/* id 1, wireType 2 =*/10).string(message.allowedValues[i]);
+                                if (message.deniedValues != null && message.deniedValues.length)
+                                    for (var i = 0; i < message.deniedValues.length; ++i)
+                                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.deniedValues[i]);
+                                if (message.allValues != null && message.hasOwnProperty("allValues"))
+                                    writer.uint32(/* id 3, wireType 0 =*/24).int32(message.allValues);
+                                if (message.suggestedValue != null && message.hasOwnProperty("suggestedValue"))
+                                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.suggestedValue);
+                                if (message.inheritFromParent != null && message.hasOwnProperty("inheritFromParent"))
+                                    writer.uint32(/* id 5, wireType 0 =*/40).bool(message.inheritFromParent);
+                                return writer;
+                            };
+    
+                            /**
+                             * Encodes the specified ListPolicy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.ListPolicy.verify|verify} messages.
+                             * @function encodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IListPolicy} message ListPolicy message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            ListPolicy.encodeDelimited = function encodeDelimited(message, writer) {
+                                return this.encode(message, writer).ldelim();
+                            };
+    
+                            /**
+                             * Decodes a ListPolicy message from the specified reader or buffer.
+                             * @function decode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @param {number} [length] Message length if known beforehand
+                             * @returns {google.cloud.orgpolicy.v1.Policy.ListPolicy} ListPolicy
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            ListPolicy.decode = function decode(reader, length) {
+                                if (!(reader instanceof $Reader))
+                                    reader = $Reader.create(reader);
+                                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.cloud.orgpolicy.v1.Policy.ListPolicy();
+                                while (reader.pos < end) {
+                                    var tag = reader.uint32();
+                                    switch (tag >>> 3) {
+                                    case 1:
+                                        if (!(message.allowedValues && message.allowedValues.length))
+                                            message.allowedValues = [];
+                                        message.allowedValues.push(reader.string());
+                                        break;
+                                    case 2:
+                                        if (!(message.deniedValues && message.deniedValues.length))
+                                            message.deniedValues = [];
+                                        message.deniedValues.push(reader.string());
+                                        break;
+                                    case 3:
+                                        message.allValues = reader.int32();
+                                        break;
+                                    case 4:
+                                        message.suggestedValue = reader.string();
+                                        break;
+                                    case 5:
+                                        message.inheritFromParent = reader.bool();
+                                        break;
+                                    default:
+                                        reader.skipType(tag & 7);
+                                        break;
+                                    }
+                                }
+                                return message;
+                            };
+    
+                            /**
+                             * Decodes a ListPolicy message from the specified reader or buffer, length delimited.
+                             * @function decodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @returns {google.cloud.orgpolicy.v1.Policy.ListPolicy} ListPolicy
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            ListPolicy.decodeDelimited = function decodeDelimited(reader) {
+                                if (!(reader instanceof $Reader))
+                                    reader = new $Reader(reader);
+                                return this.decode(reader, reader.uint32());
+                            };
+    
+                            /**
+                             * Verifies a ListPolicy message.
+                             * @function verify
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {Object.<string,*>} message Plain object to verify
+                             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                             */
+                            ListPolicy.verify = function verify(message) {
+                                if (typeof message !== "object" || message === null)
+                                    return "object expected";
+                                if (message.allowedValues != null && message.hasOwnProperty("allowedValues")) {
+                                    if (!Array.isArray(message.allowedValues))
+                                        return "allowedValues: array expected";
+                                    for (var i = 0; i < message.allowedValues.length; ++i)
+                                        if (!$util.isString(message.allowedValues[i]))
+                                            return "allowedValues: string[] expected";
+                                }
+                                if (message.deniedValues != null && message.hasOwnProperty("deniedValues")) {
+                                    if (!Array.isArray(message.deniedValues))
+                                        return "deniedValues: array expected";
+                                    for (var i = 0; i < message.deniedValues.length; ++i)
+                                        if (!$util.isString(message.deniedValues[i]))
+                                            return "deniedValues: string[] expected";
+                                }
+                                if (message.allValues != null && message.hasOwnProperty("allValues"))
+                                    switch (message.allValues) {
+                                    default:
+                                        return "allValues: enum value expected";
+                                    case 0:
+                                    case 1:
+                                    case 2:
+                                        break;
+                                    }
+                                if (message.suggestedValue != null && message.hasOwnProperty("suggestedValue"))
+                                    if (!$util.isString(message.suggestedValue))
+                                        return "suggestedValue: string expected";
+                                if (message.inheritFromParent != null && message.hasOwnProperty("inheritFromParent"))
+                                    if (typeof message.inheritFromParent !== "boolean")
+                                        return "inheritFromParent: boolean expected";
+                                return null;
+                            };
+    
+                            /**
+                             * Creates a ListPolicy message from a plain object. Also converts values to their respective internal types.
+                             * @function fromObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {Object.<string,*>} object Plain object
+                             * @returns {google.cloud.orgpolicy.v1.Policy.ListPolicy} ListPolicy
+                             */
+                            ListPolicy.fromObject = function fromObject(object) {
+                                if (object instanceof $root.google.cloud.orgpolicy.v1.Policy.ListPolicy)
+                                    return object;
+                                var message = new $root.google.cloud.orgpolicy.v1.Policy.ListPolicy();
+                                if (object.allowedValues) {
+                                    if (!Array.isArray(object.allowedValues))
+                                        throw TypeError(".google.cloud.orgpolicy.v1.Policy.ListPolicy.allowedValues: array expected");
+                                    message.allowedValues = [];
+                                    for (var i = 0; i < object.allowedValues.length; ++i)
+                                        message.allowedValues[i] = String(object.allowedValues[i]);
+                                }
+                                if (object.deniedValues) {
+                                    if (!Array.isArray(object.deniedValues))
+                                        throw TypeError(".google.cloud.orgpolicy.v1.Policy.ListPolicy.deniedValues: array expected");
+                                    message.deniedValues = [];
+                                    for (var i = 0; i < object.deniedValues.length; ++i)
+                                        message.deniedValues[i] = String(object.deniedValues[i]);
+                                }
+                                switch (object.allValues) {
+                                case "ALL_VALUES_UNSPECIFIED":
+                                case 0:
+                                    message.allValues = 0;
+                                    break;
+                                case "ALLOW":
+                                case 1:
+                                    message.allValues = 1;
+                                    break;
+                                case "DENY":
+                                case 2:
+                                    message.allValues = 2;
+                                    break;
+                                }
+                                if (object.suggestedValue != null)
+                                    message.suggestedValue = String(object.suggestedValue);
+                                if (object.inheritFromParent != null)
+                                    message.inheritFromParent = Boolean(object.inheritFromParent);
+                                return message;
+                            };
+    
+                            /**
+                             * Creates a plain object from a ListPolicy message. Also converts values to other types if specified.
+                             * @function toObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.ListPolicy} message ListPolicy
+                             * @param {$protobuf.IConversionOptions} [options] Conversion options
+                             * @returns {Object.<string,*>} Plain object
+                             */
+                            ListPolicy.toObject = function toObject(message, options) {
+                                if (!options)
+                                    options = {};
+                                var object = {};
+                                if (options.arrays || options.defaults) {
+                                    object.allowedValues = [];
+                                    object.deniedValues = [];
+                                }
+                                if (options.defaults) {
+                                    object.allValues = options.enums === String ? "ALL_VALUES_UNSPECIFIED" : 0;
+                                    object.suggestedValue = "";
+                                    object.inheritFromParent = false;
+                                }
+                                if (message.allowedValues && message.allowedValues.length) {
+                                    object.allowedValues = [];
+                                    for (var j = 0; j < message.allowedValues.length; ++j)
+                                        object.allowedValues[j] = message.allowedValues[j];
+                                }
+                                if (message.deniedValues && message.deniedValues.length) {
+                                    object.deniedValues = [];
+                                    for (var j = 0; j < message.deniedValues.length; ++j)
+                                        object.deniedValues[j] = message.deniedValues[j];
+                                }
+                                if (message.allValues != null && message.hasOwnProperty("allValues"))
+                                    object.allValues = options.enums === String ? $root.google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues[message.allValues] : message.allValues;
+                                if (message.suggestedValue != null && message.hasOwnProperty("suggestedValue"))
+                                    object.suggestedValue = message.suggestedValue;
+                                if (message.inheritFromParent != null && message.hasOwnProperty("inheritFromParent"))
+                                    object.inheritFromParent = message.inheritFromParent;
+                                return object;
+                            };
+    
+                            /**
+                             * Converts this ListPolicy to JSON.
+                             * @function toJSON
+                             * @memberof google.cloud.orgpolicy.v1.Policy.ListPolicy
+                             * @instance
+                             * @returns {Object.<string,*>} JSON object
+                             */
+                            ListPolicy.prototype.toJSON = function toJSON() {
+                                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                            };
+    
+                            /**
+                             * AllValues enum.
+                             * @name google.cloud.orgpolicy.v1.Policy.ListPolicy.AllValues
+                             * @enum {string}
+                             * @property {number} ALL_VALUES_UNSPECIFIED=0 ALL_VALUES_UNSPECIFIED value
+                             * @property {number} ALLOW=1 ALLOW value
+                             * @property {number} DENY=2 DENY value
+                             */
+                            ListPolicy.AllValues = (function() {
+                                var valuesById = {}, values = Object.create(valuesById);
+                                values[valuesById[0] = "ALL_VALUES_UNSPECIFIED"] = 0;
+                                values[valuesById[1] = "ALLOW"] = 1;
+                                values[valuesById[2] = "DENY"] = 2;
+                                return values;
+                            })();
+    
+                            return ListPolicy;
+                        })();
+    
+                        Policy.BooleanPolicy = (function() {
+    
+                            /**
+                             * Properties of a BooleanPolicy.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @interface IBooleanPolicy
+                             * @property {boolean|null} [enforced] BooleanPolicy enforced
+                             */
+    
+                            /**
+                             * Constructs a new BooleanPolicy.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @classdesc Represents a BooleanPolicy.
+                             * @implements IBooleanPolicy
+                             * @constructor
+                             * @param {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy=} [properties] Properties to set
+                             */
+                            function BooleanPolicy(properties) {
+                                if (properties)
+                                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                        if (properties[keys[i]] != null)
+                                            this[keys[i]] = properties[keys[i]];
+                            }
+    
+                            /**
+                             * BooleanPolicy enforced.
+                             * @member {boolean} enforced
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @instance
+                             */
+                            BooleanPolicy.prototype.enforced = false;
+    
+                            /**
+                             * Creates a new BooleanPolicy instance using the specified properties.
+                             * @function create
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy=} [properties] Properties to set
+                             * @returns {google.cloud.orgpolicy.v1.Policy.BooleanPolicy} BooleanPolicy instance
+                             */
+                            BooleanPolicy.create = function create(properties) {
+                                return new BooleanPolicy(properties);
+                            };
+    
+                            /**
+                             * Encodes the specified BooleanPolicy message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.BooleanPolicy.verify|verify} messages.
+                             * @function encode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy} message BooleanPolicy message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            BooleanPolicy.encode = function encode(message, writer) {
+                                if (!writer)
+                                    writer = $Writer.create();
+                                if (message.enforced != null && message.hasOwnProperty("enforced"))
+                                    writer.uint32(/* id 1, wireType 0 =*/8).bool(message.enforced);
+                                return writer;
+                            };
+    
+                            /**
+                             * Encodes the specified BooleanPolicy message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.BooleanPolicy.verify|verify} messages.
+                             * @function encodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IBooleanPolicy} message BooleanPolicy message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            BooleanPolicy.encodeDelimited = function encodeDelimited(message, writer) {
+                                return this.encode(message, writer).ldelim();
+                            };
+    
+                            /**
+                             * Decodes a BooleanPolicy message from the specified reader or buffer.
+                             * @function decode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @param {number} [length] Message length if known beforehand
+                             * @returns {google.cloud.orgpolicy.v1.Policy.BooleanPolicy} BooleanPolicy
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            BooleanPolicy.decode = function decode(reader, length) {
+                                if (!(reader instanceof $Reader))
+                                    reader = $Reader.create(reader);
+                                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy();
+                                while (reader.pos < end) {
+                                    var tag = reader.uint32();
+                                    switch (tag >>> 3) {
+                                    case 1:
+                                        message.enforced = reader.bool();
+                                        break;
+                                    default:
+                                        reader.skipType(tag & 7);
+                                        break;
+                                    }
+                                }
+                                return message;
+                            };
+    
+                            /**
+                             * Decodes a BooleanPolicy message from the specified reader or buffer, length delimited.
+                             * @function decodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @returns {google.cloud.orgpolicy.v1.Policy.BooleanPolicy} BooleanPolicy
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            BooleanPolicy.decodeDelimited = function decodeDelimited(reader) {
+                                if (!(reader instanceof $Reader))
+                                    reader = new $Reader(reader);
+                                return this.decode(reader, reader.uint32());
+                            };
+    
+                            /**
+                             * Verifies a BooleanPolicy message.
+                             * @function verify
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {Object.<string,*>} message Plain object to verify
+                             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                             */
+                            BooleanPolicy.verify = function verify(message) {
+                                if (typeof message !== "object" || message === null)
+                                    return "object expected";
+                                if (message.enforced != null && message.hasOwnProperty("enforced"))
+                                    if (typeof message.enforced !== "boolean")
+                                        return "enforced: boolean expected";
+                                return null;
+                            };
+    
+                            /**
+                             * Creates a BooleanPolicy message from a plain object. Also converts values to their respective internal types.
+                             * @function fromObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {Object.<string,*>} object Plain object
+                             * @returns {google.cloud.orgpolicy.v1.Policy.BooleanPolicy} BooleanPolicy
+                             */
+                            BooleanPolicy.fromObject = function fromObject(object) {
+                                if (object instanceof $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy)
+                                    return object;
+                                var message = new $root.google.cloud.orgpolicy.v1.Policy.BooleanPolicy();
+                                if (object.enforced != null)
+                                    message.enforced = Boolean(object.enforced);
+                                return message;
+                            };
+    
+                            /**
+                             * Creates a plain object from a BooleanPolicy message. Also converts values to other types if specified.
+                             * @function toObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.BooleanPolicy} message BooleanPolicy
+                             * @param {$protobuf.IConversionOptions} [options] Conversion options
+                             * @returns {Object.<string,*>} Plain object
+                             */
+                            BooleanPolicy.toObject = function toObject(message, options) {
+                                if (!options)
+                                    options = {};
+                                var object = {};
+                                if (options.defaults)
+                                    object.enforced = false;
+                                if (message.enforced != null && message.hasOwnProperty("enforced"))
+                                    object.enforced = message.enforced;
+                                return object;
+                            };
+    
+                            /**
+                             * Converts this BooleanPolicy to JSON.
+                             * @function toJSON
+                             * @memberof google.cloud.orgpolicy.v1.Policy.BooleanPolicy
+                             * @instance
+                             * @returns {Object.<string,*>} JSON object
+                             */
+                            BooleanPolicy.prototype.toJSON = function toJSON() {
+                                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                            };
+    
+                            return BooleanPolicy;
+                        })();
+    
+                        Policy.RestoreDefault = (function() {
+    
+                            /**
+                             * Properties of a RestoreDefault.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @interface IRestoreDefault
+                             */
+    
+                            /**
+                             * Constructs a new RestoreDefault.
+                             * @memberof google.cloud.orgpolicy.v1.Policy
+                             * @classdesc Represents a RestoreDefault.
+                             * @implements IRestoreDefault
+                             * @constructor
+                             * @param {google.cloud.orgpolicy.v1.Policy.IRestoreDefault=} [properties] Properties to set
+                             */
+                            function RestoreDefault(properties) {
+                                if (properties)
+                                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                        if (properties[keys[i]] != null)
+                                            this[keys[i]] = properties[keys[i]];
+                            }
+    
+                            /**
+                             * Creates a new RestoreDefault instance using the specified properties.
+                             * @function create
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IRestoreDefault=} [properties] Properties to set
+                             * @returns {google.cloud.orgpolicy.v1.Policy.RestoreDefault} RestoreDefault instance
+                             */
+                            RestoreDefault.create = function create(properties) {
+                                return new RestoreDefault(properties);
+                            };
+    
+                            /**
+                             * Encodes the specified RestoreDefault message. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.RestoreDefault.verify|verify} messages.
+                             * @function encode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IRestoreDefault} message RestoreDefault message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            RestoreDefault.encode = function encode(message, writer) {
+                                if (!writer)
+                                    writer = $Writer.create();
+                                return writer;
+                            };
+    
+                            /**
+                             * Encodes the specified RestoreDefault message, length delimited. Does not implicitly {@link google.cloud.orgpolicy.v1.Policy.RestoreDefault.verify|verify} messages.
+                             * @function encodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.IRestoreDefault} message RestoreDefault message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            RestoreDefault.encodeDelimited = function encodeDelimited(message, writer) {
+                                return this.encode(message, writer).ldelim();
+                            };
+    
+                            /**
+                             * Decodes a RestoreDefault message from the specified reader or buffer.
+                             * @function decode
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @param {number} [length] Message length if known beforehand
+                             * @returns {google.cloud.orgpolicy.v1.Policy.RestoreDefault} RestoreDefault
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            RestoreDefault.decode = function decode(reader, length) {
+                                if (!(reader instanceof $Reader))
+                                    reader = $Reader.create(reader);
+                                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault();
+                                while (reader.pos < end) {
+                                    var tag = reader.uint32();
+                                    switch (tag >>> 3) {
+                                    default:
+                                        reader.skipType(tag & 7);
+                                        break;
+                                    }
+                                }
+                                return message;
+                            };
+    
+                            /**
+                             * Decodes a RestoreDefault message from the specified reader or buffer, length delimited.
+                             * @function decodeDelimited
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @returns {google.cloud.orgpolicy.v1.Policy.RestoreDefault} RestoreDefault
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            RestoreDefault.decodeDelimited = function decodeDelimited(reader) {
+                                if (!(reader instanceof $Reader))
+                                    reader = new $Reader(reader);
+                                return this.decode(reader, reader.uint32());
+                            };
+    
+                            /**
+                             * Verifies a RestoreDefault message.
+                             * @function verify
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {Object.<string,*>} message Plain object to verify
+                             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                             */
+                            RestoreDefault.verify = function verify(message) {
+                                if (typeof message !== "object" || message === null)
+                                    return "object expected";
+                                return null;
+                            };
+    
+                            /**
+                             * Creates a RestoreDefault message from a plain object. Also converts values to their respective internal types.
+                             * @function fromObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {Object.<string,*>} object Plain object
+                             * @returns {google.cloud.orgpolicy.v1.Policy.RestoreDefault} RestoreDefault
+                             */
+                            RestoreDefault.fromObject = function fromObject(object) {
+                                if (object instanceof $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault)
+                                    return object;
+                                return new $root.google.cloud.orgpolicy.v1.Policy.RestoreDefault();
+                            };
+    
+                            /**
+                             * Creates a plain object from a RestoreDefault message. Also converts values to other types if specified.
+                             * @function toObject
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @static
+                             * @param {google.cloud.orgpolicy.v1.Policy.RestoreDefault} message RestoreDefault
+                             * @param {$protobuf.IConversionOptions} [options] Conversion options
+                             * @returns {Object.<string,*>} Plain object
+                             */
+                            RestoreDefault.toObject = function toObject() {
+                                return {};
+                            };
+    
+                            /**
+                             * Converts this RestoreDefault to JSON.
+                             * @function toJSON
+                             * @memberof google.cloud.orgpolicy.v1.Policy.RestoreDefault
+                             * @instance
+                             * @returns {Object.<string,*>} JSON object
+                             */
+                            RestoreDefault.prototype.toJSON = function toJSON() {
+                                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                            };
+    
+                            return RestoreDefault;
+                        })();
+    
+                        return Policy;
+                    })();
+    
+                    return v1;
+                })();
+    
+                return orgpolicy;
+            })();
+    
             return cloud;
         })();
     
@@ -28637,6 +29894,390 @@
                 return GeneratedCodeInfo;
             })();
     
+            protobuf.Empty = (function() {
+    
+                /**
+                 * Properties of an Empty.
+                 * @memberof google.protobuf
+                 * @interface IEmpty
+                 */
+    
+                /**
+                 * Constructs a new Empty.
+                 * @memberof google.protobuf
+                 * @classdesc Represents an Empty.
+                 * @implements IEmpty
+                 * @constructor
+                 * @param {google.protobuf.IEmpty=} [properties] Properties to set
+                 */
+                function Empty(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+    
+                /**
+                 * Creates a new Empty instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {google.protobuf.IEmpty=} [properties] Properties to set
+                 * @returns {google.protobuf.Empty} Empty instance
+                 */
+                Empty.create = function create(properties) {
+                    return new Empty(properties);
+                };
+    
+                /**
+                 * Encodes the specified Empty message. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {google.protobuf.IEmpty} message Empty message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Empty.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    return writer;
+                };
+    
+                /**
+                 * Encodes the specified Empty message, length delimited. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {google.protobuf.IEmpty} message Empty message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Empty.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+    
+                /**
+                 * Decodes an Empty message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.Empty} Empty
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Empty.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Empty();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+    
+                /**
+                 * Decodes an Empty message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.Empty} Empty
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Empty.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+    
+                /**
+                 * Verifies an Empty message.
+                 * @function verify
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Empty.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    return null;
+                };
+    
+                /**
+                 * Creates an Empty message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.Empty} Empty
+                 */
+                Empty.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.Empty)
+                        return object;
+                    return new $root.google.protobuf.Empty();
+                };
+    
+                /**
+                 * Creates a plain object from an Empty message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.Empty
+                 * @static
+                 * @param {google.protobuf.Empty} message Empty
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Empty.toObject = function toObject() {
+                    return {};
+                };
+    
+                /**
+                 * Converts this Empty to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.Empty
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Empty.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+    
+                return Empty;
+            })();
+    
+            protobuf.Timestamp = (function() {
+    
+                /**
+                 * Properties of a Timestamp.
+                 * @memberof google.protobuf
+                 * @interface ITimestamp
+                 * @property {number|Long|null} [seconds] Timestamp seconds
+                 * @property {number|null} [nanos] Timestamp nanos
+                 */
+    
+                /**
+                 * Constructs a new Timestamp.
+                 * @memberof google.protobuf
+                 * @classdesc Represents a Timestamp.
+                 * @implements ITimestamp
+                 * @constructor
+                 * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+                 */
+                function Timestamp(properties) {
+                    if (properties)
+                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                            if (properties[keys[i]] != null)
+                                this[keys[i]] = properties[keys[i]];
+                }
+    
+                /**
+                 * Timestamp seconds.
+                 * @member {number|Long} seconds
+                 * @memberof google.protobuf.Timestamp
+                 * @instance
+                 */
+                Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
+    
+                /**
+                 * Timestamp nanos.
+                 * @member {number} nanos
+                 * @memberof google.protobuf.Timestamp
+                 * @instance
+                 */
+                Timestamp.prototype.nanos = 0;
+    
+                /**
+                 * Creates a new Timestamp instance using the specified properties.
+                 * @function create
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {google.protobuf.ITimestamp=} [properties] Properties to set
+                 * @returns {google.protobuf.Timestamp} Timestamp instance
+                 */
+                Timestamp.create = function create(properties) {
+                    return new Timestamp(properties);
+                };
+    
+                /**
+                 * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+                 * @function encode
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Timestamp.encode = function encode(message, writer) {
+                    if (!writer)
+                        writer = $Writer.create();
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
+                        writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
+                        writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
+                    return writer;
+                };
+    
+                /**
+                 * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
+                 * @function encodeDelimited
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
+                 * @param {$protobuf.Writer} [writer] Writer to encode to
+                 * @returns {$protobuf.Writer} Writer
+                 */
+                Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
+                    return this.encode(message, writer).ldelim();
+                };
+    
+                /**
+                 * Decodes a Timestamp message from the specified reader or buffer.
+                 * @function decode
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @param {number} [length] Message length if known beforehand
+                 * @returns {google.protobuf.Timestamp} Timestamp
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Timestamp.decode = function decode(reader, length) {
+                    if (!(reader instanceof $Reader))
+                        reader = $Reader.create(reader);
+                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
+                    while (reader.pos < end) {
+                        var tag = reader.uint32();
+                        switch (tag >>> 3) {
+                        case 1:
+                            message.seconds = reader.int64();
+                            break;
+                        case 2:
+                            message.nanos = reader.int32();
+                            break;
+                        default:
+                            reader.skipType(tag & 7);
+                            break;
+                        }
+                    }
+                    return message;
+                };
+    
+                /**
+                 * Decodes a Timestamp message from the specified reader or buffer, length delimited.
+                 * @function decodeDelimited
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                 * @returns {google.protobuf.Timestamp} Timestamp
+                 * @throws {Error} If the payload is not a reader or valid buffer
+                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                 */
+                Timestamp.decodeDelimited = function decodeDelimited(reader) {
+                    if (!(reader instanceof $Reader))
+                        reader = new $Reader(reader);
+                    return this.decode(reader, reader.uint32());
+                };
+    
+                /**
+                 * Verifies a Timestamp message.
+                 * @function verify
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {Object.<string,*>} message Plain object to verify
+                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                 */
+                Timestamp.verify = function verify(message) {
+                    if (typeof message !== "object" || message === null)
+                        return "object expected";
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
+                        if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
+                            return "seconds: integer|Long expected";
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
+                        if (!$util.isInteger(message.nanos))
+                            return "nanos: integer expected";
+                    return null;
+                };
+    
+                /**
+                 * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
+                 * @function fromObject
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {Object.<string,*>} object Plain object
+                 * @returns {google.protobuf.Timestamp} Timestamp
+                 */
+                Timestamp.fromObject = function fromObject(object) {
+                    if (object instanceof $root.google.protobuf.Timestamp)
+                        return object;
+                    var message = new $root.google.protobuf.Timestamp();
+                    if (object.seconds != null)
+                        if ($util.Long)
+                            (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
+                        else if (typeof object.seconds === "string")
+                            message.seconds = parseInt(object.seconds, 10);
+                        else if (typeof object.seconds === "number")
+                            message.seconds = object.seconds;
+                        else if (typeof object.seconds === "object")
+                            message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
+                    if (object.nanos != null)
+                        message.nanos = object.nanos | 0;
+                    return message;
+                };
+    
+                /**
+                 * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
+                 * @function toObject
+                 * @memberof google.protobuf.Timestamp
+                 * @static
+                 * @param {google.protobuf.Timestamp} message Timestamp
+                 * @param {$protobuf.IConversionOptions} [options] Conversion options
+                 * @returns {Object.<string,*>} Plain object
+                 */
+                Timestamp.toObject = function toObject(message, options) {
+                    if (!options)
+                        options = {};
+                    var object = {};
+                    if (options.defaults) {
+                        if ($util.Long) {
+                            var long = new $util.Long(0, 0, false);
+                            object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
+                        } else
+                            object.seconds = options.longs === String ? "0" : 0;
+                        object.nanos = 0;
+                    }
+                    if (message.seconds != null && message.hasOwnProperty("seconds"))
+                        if (typeof message.seconds === "number")
+                            object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
+                        else
+                            object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
+                    if (message.nanos != null && message.hasOwnProperty("nanos"))
+                        object.nanos = message.nanos;
+                    return object;
+                };
+    
+                /**
+                 * Converts this Timestamp to JSON.
+                 * @function toJSON
+                 * @memberof google.protobuf.Timestamp
+                 * @instance
+                 * @returns {Object.<string,*>} JSON object
+                 */
+                Timestamp.prototype.toJSON = function toJSON() {
+                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                };
+    
+                return Timestamp;
+            })();
+    
             protobuf.Any = (function() {
     
                 /**
@@ -29656,230 +31297,6 @@
                 return ListValue;
             })();
     
-            protobuf.Timestamp = (function() {
-    
-                /**
-                 * Properties of a Timestamp.
-                 * @memberof google.protobuf
-                 * @interface ITimestamp
-                 * @property {number|Long|null} [seconds] Timestamp seconds
-                 * @property {number|null} [nanos] Timestamp nanos
-                 */
-    
-                /**
-                 * Constructs a new Timestamp.
-                 * @memberof google.protobuf
-                 * @classdesc Represents a Timestamp.
-                 * @implements ITimestamp
-                 * @constructor
-                 * @param {google.protobuf.ITimestamp=} [properties] Properties to set
-                 */
-                function Timestamp(properties) {
-                    if (properties)
-                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
-                                this[keys[i]] = properties[keys[i]];
-                }
-    
-                /**
-                 * Timestamp seconds.
-                 * @member {number|Long} seconds
-                 * @memberof google.protobuf.Timestamp
-                 * @instance
-                 */
-                Timestamp.prototype.seconds = $util.Long ? $util.Long.fromBits(0,0,false) : 0;
-    
-                /**
-                 * Timestamp nanos.
-                 * @member {number} nanos
-                 * @memberof google.protobuf.Timestamp
-                 * @instance
-                 */
-                Timestamp.prototype.nanos = 0;
-    
-                /**
-                 * Creates a new Timestamp instance using the specified properties.
-                 * @function create
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {google.protobuf.ITimestamp=} [properties] Properties to set
-                 * @returns {google.protobuf.Timestamp} Timestamp instance
-                 */
-                Timestamp.create = function create(properties) {
-                    return new Timestamp(properties);
-                };
-    
-                /**
-                 * Encodes the specified Timestamp message. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-                 * @function encode
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                Timestamp.encode = function encode(message, writer) {
-                    if (!writer)
-                        writer = $Writer.create();
-                    if (message.seconds != null && message.hasOwnProperty("seconds"))
-                        writer.uint32(/* id 1, wireType 0 =*/8).int64(message.seconds);
-                    if (message.nanos != null && message.hasOwnProperty("nanos"))
-                        writer.uint32(/* id 2, wireType 0 =*/16).int32(message.nanos);
-                    return writer;
-                };
-    
-                /**
-                 * Encodes the specified Timestamp message, length delimited. Does not implicitly {@link google.protobuf.Timestamp.verify|verify} messages.
-                 * @function encodeDelimited
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {google.protobuf.ITimestamp} message Timestamp message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                Timestamp.encodeDelimited = function encodeDelimited(message, writer) {
-                    return this.encode(message, writer).ldelim();
-                };
-    
-                /**
-                 * Decodes a Timestamp message from the specified reader or buffer.
-                 * @function decode
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @param {number} [length] Message length if known beforehand
-                 * @returns {google.protobuf.Timestamp} Timestamp
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                Timestamp.decode = function decode(reader, length) {
-                    if (!(reader instanceof $Reader))
-                        reader = $Reader.create(reader);
-                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Timestamp();
-                    while (reader.pos < end) {
-                        var tag = reader.uint32();
-                        switch (tag >>> 3) {
-                        case 1:
-                            message.seconds = reader.int64();
-                            break;
-                        case 2:
-                            message.nanos = reader.int32();
-                            break;
-                        default:
-                            reader.skipType(tag & 7);
-                            break;
-                        }
-                    }
-                    return message;
-                };
-    
-                /**
-                 * Decodes a Timestamp message from the specified reader or buffer, length delimited.
-                 * @function decodeDelimited
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @returns {google.protobuf.Timestamp} Timestamp
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                Timestamp.decodeDelimited = function decodeDelimited(reader) {
-                    if (!(reader instanceof $Reader))
-                        reader = new $Reader(reader);
-                    return this.decode(reader, reader.uint32());
-                };
-    
-                /**
-                 * Verifies a Timestamp message.
-                 * @function verify
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {Object.<string,*>} message Plain object to verify
-                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                 */
-                Timestamp.verify = function verify(message) {
-                    if (typeof message !== "object" || message === null)
-                        return "object expected";
-                    if (message.seconds != null && message.hasOwnProperty("seconds"))
-                        if (!$util.isInteger(message.seconds) && !(message.seconds && $util.isInteger(message.seconds.low) && $util.isInteger(message.seconds.high)))
-                            return "seconds: integer|Long expected";
-                    if (message.nanos != null && message.hasOwnProperty("nanos"))
-                        if (!$util.isInteger(message.nanos))
-                            return "nanos: integer expected";
-                    return null;
-                };
-    
-                /**
-                 * Creates a Timestamp message from a plain object. Also converts values to their respective internal types.
-                 * @function fromObject
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {Object.<string,*>} object Plain object
-                 * @returns {google.protobuf.Timestamp} Timestamp
-                 */
-                Timestamp.fromObject = function fromObject(object) {
-                    if (object instanceof $root.google.protobuf.Timestamp)
-                        return object;
-                    var message = new $root.google.protobuf.Timestamp();
-                    if (object.seconds != null)
-                        if ($util.Long)
-                            (message.seconds = $util.Long.fromValue(object.seconds)).unsigned = false;
-                        else if (typeof object.seconds === "string")
-                            message.seconds = parseInt(object.seconds, 10);
-                        else if (typeof object.seconds === "number")
-                            message.seconds = object.seconds;
-                        else if (typeof object.seconds === "object")
-                            message.seconds = new $util.LongBits(object.seconds.low >>> 0, object.seconds.high >>> 0).toNumber();
-                    if (object.nanos != null)
-                        message.nanos = object.nanos | 0;
-                    return message;
-                };
-    
-                /**
-                 * Creates a plain object from a Timestamp message. Also converts values to other types if specified.
-                 * @function toObject
-                 * @memberof google.protobuf.Timestamp
-                 * @static
-                 * @param {google.protobuf.Timestamp} message Timestamp
-                 * @param {$protobuf.IConversionOptions} [options] Conversion options
-                 * @returns {Object.<string,*>} Plain object
-                 */
-                Timestamp.toObject = function toObject(message, options) {
-                    if (!options)
-                        options = {};
-                    var object = {};
-                    if (options.defaults) {
-                        if ($util.Long) {
-                            var long = new $util.Long(0, 0, false);
-                            object.seconds = options.longs === String ? long.toString() : options.longs === Number ? long.toNumber() : long;
-                        } else
-                            object.seconds = options.longs === String ? "0" : 0;
-                        object.nanos = 0;
-                    }
-                    if (message.seconds != null && message.hasOwnProperty("seconds"))
-                        if (typeof message.seconds === "number")
-                            object.seconds = options.longs === String ? String(message.seconds) : message.seconds;
-                        else
-                            object.seconds = options.longs === String ? $util.Long.prototype.toString.call(message.seconds) : options.longs === Number ? new $util.LongBits(message.seconds.low >>> 0, message.seconds.high >>> 0).toNumber() : message.seconds;
-                    if (message.nanos != null && message.hasOwnProperty("nanos"))
-                        object.nanos = message.nanos;
-                    return object;
-                };
-    
-                /**
-                 * Converts this Timestamp to JSON.
-                 * @function toJSON
-                 * @memberof google.protobuf.Timestamp
-                 * @instance
-                 * @returns {Object.<string,*>} JSON object
-                 */
-                Timestamp.prototype.toJSON = function toJSON() {
-                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                };
-    
-                return Timestamp;
-            })();
-    
             protobuf.Duration = (function() {
     
                 /**
@@ -30102,166 +31519,6 @@
                 };
     
                 return Duration;
-            })();
-    
-            protobuf.Empty = (function() {
-    
-                /**
-                 * Properties of an Empty.
-                 * @memberof google.protobuf
-                 * @interface IEmpty
-                 */
-    
-                /**
-                 * Constructs a new Empty.
-                 * @memberof google.protobuf
-                 * @classdesc Represents an Empty.
-                 * @implements IEmpty
-                 * @constructor
-                 * @param {google.protobuf.IEmpty=} [properties] Properties to set
-                 */
-                function Empty(properties) {
-                    if (properties)
-                        for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
-                            if (properties[keys[i]] != null)
-                                this[keys[i]] = properties[keys[i]];
-                }
-    
-                /**
-                 * Creates a new Empty instance using the specified properties.
-                 * @function create
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {google.protobuf.IEmpty=} [properties] Properties to set
-                 * @returns {google.protobuf.Empty} Empty instance
-                 */
-                Empty.create = function create(properties) {
-                    return new Empty(properties);
-                };
-    
-                /**
-                 * Encodes the specified Empty message. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
-                 * @function encode
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {google.protobuf.IEmpty} message Empty message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                Empty.encode = function encode(message, writer) {
-                    if (!writer)
-                        writer = $Writer.create();
-                    return writer;
-                };
-    
-                /**
-                 * Encodes the specified Empty message, length delimited. Does not implicitly {@link google.protobuf.Empty.verify|verify} messages.
-                 * @function encodeDelimited
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {google.protobuf.IEmpty} message Empty message or plain object to encode
-                 * @param {$protobuf.Writer} [writer] Writer to encode to
-                 * @returns {$protobuf.Writer} Writer
-                 */
-                Empty.encodeDelimited = function encodeDelimited(message, writer) {
-                    return this.encode(message, writer).ldelim();
-                };
-    
-                /**
-                 * Decodes an Empty message from the specified reader or buffer.
-                 * @function decode
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @param {number} [length] Message length if known beforehand
-                 * @returns {google.protobuf.Empty} Empty
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                Empty.decode = function decode(reader, length) {
-                    if (!(reader instanceof $Reader))
-                        reader = $Reader.create(reader);
-                    var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.protobuf.Empty();
-                    while (reader.pos < end) {
-                        var tag = reader.uint32();
-                        switch (tag >>> 3) {
-                        default:
-                            reader.skipType(tag & 7);
-                            break;
-                        }
-                    }
-                    return message;
-                };
-    
-                /**
-                 * Decodes an Empty message from the specified reader or buffer, length delimited.
-                 * @function decodeDelimited
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
-                 * @returns {google.protobuf.Empty} Empty
-                 * @throws {Error} If the payload is not a reader or valid buffer
-                 * @throws {$protobuf.util.ProtocolError} If required fields are missing
-                 */
-                Empty.decodeDelimited = function decodeDelimited(reader) {
-                    if (!(reader instanceof $Reader))
-                        reader = new $Reader(reader);
-                    return this.decode(reader, reader.uint32());
-                };
-    
-                /**
-                 * Verifies an Empty message.
-                 * @function verify
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {Object.<string,*>} message Plain object to verify
-                 * @returns {string|null} `null` if valid, otherwise the reason why it is not
-                 */
-                Empty.verify = function verify(message) {
-                    if (typeof message !== "object" || message === null)
-                        return "object expected";
-                    return null;
-                };
-    
-                /**
-                 * Creates an Empty message from a plain object. Also converts values to their respective internal types.
-                 * @function fromObject
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {Object.<string,*>} object Plain object
-                 * @returns {google.protobuf.Empty} Empty
-                 */
-                Empty.fromObject = function fromObject(object) {
-                    if (object instanceof $root.google.protobuf.Empty)
-                        return object;
-                    return new $root.google.protobuf.Empty();
-                };
-    
-                /**
-                 * Creates a plain object from an Empty message. Also converts values to other types if specified.
-                 * @function toObject
-                 * @memberof google.protobuf.Empty
-                 * @static
-                 * @param {google.protobuf.Empty} message Empty
-                 * @param {$protobuf.IConversionOptions} [options] Conversion options
-                 * @returns {Object.<string,*>} Plain object
-                 */
-                Empty.toObject = function toObject() {
-                    return {};
-                };
-    
-                /**
-                 * Converts this Empty to JSON.
-                 * @function toJSON
-                 * @memberof google.protobuf.Empty
-                 * @instance
-                 * @returns {Object.<string,*>} JSON object
-                 */
-                Empty.prototype.toJSON = function toJSON() {
-                    return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
-                };
-    
-                return Empty;
             })();
     
             protobuf.FieldMask = (function() {
@@ -32108,6 +33365,3242 @@
             })();
     
             return type;
+        })();
+    
+        google.identity = (function() {
+    
+            /**
+             * Namespace identity.
+             * @memberof google
+             * @namespace
+             */
+            var identity = {};
+    
+            identity.accesscontextmanager = (function() {
+    
+                /**
+                 * Namespace accesscontextmanager.
+                 * @memberof google.identity
+                 * @namespace
+                 */
+                var accesscontextmanager = {};
+    
+                accesscontextmanager.v1 = (function() {
+    
+                    /**
+                     * Namespace v1.
+                     * @memberof google.identity.accesscontextmanager
+                     * @namespace
+                     */
+                    var v1 = {};
+    
+                    v1.AccessLevel = (function() {
+    
+                        /**
+                         * Properties of an AccessLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IAccessLevel
+                         * @property {string|null} [name] AccessLevel name
+                         * @property {string|null} [title] AccessLevel title
+                         * @property {string|null} [description] AccessLevel description
+                         * @property {google.identity.accesscontextmanager.v1.IBasicLevel|null} [basic] AccessLevel basic
+                         * @property {google.identity.accesscontextmanager.v1.ICustomLevel|null} [custom] AccessLevel custom
+                         * @property {google.protobuf.ITimestamp|null} [createTime] AccessLevel createTime
+                         * @property {google.protobuf.ITimestamp|null} [updateTime] AccessLevel updateTime
+                         */
+    
+                        /**
+                         * Constructs a new AccessLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents an AccessLevel.
+                         * @implements IAccessLevel
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IAccessLevel=} [properties] Properties to set
+                         */
+                        function AccessLevel(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * AccessLevel name.
+                         * @member {string} name
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.name = "";
+    
+                        /**
+                         * AccessLevel title.
+                         * @member {string} title
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.title = "";
+    
+                        /**
+                         * AccessLevel description.
+                         * @member {string} description
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.description = "";
+    
+                        /**
+                         * AccessLevel basic.
+                         * @member {google.identity.accesscontextmanager.v1.IBasicLevel|null|undefined} basic
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.basic = null;
+    
+                        /**
+                         * AccessLevel custom.
+                         * @member {google.identity.accesscontextmanager.v1.ICustomLevel|null|undefined} custom
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.custom = null;
+    
+                        /**
+                         * AccessLevel createTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} createTime
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.createTime = null;
+    
+                        /**
+                         * AccessLevel updateTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} updateTime
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        AccessLevel.prototype.updateTime = null;
+    
+                        // OneOf field names bound to virtual getters and setters
+                        var $oneOfFields;
+    
+                        /**
+                         * AccessLevel level.
+                         * @member {"basic"|"custom"|undefined} level
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         */
+                        Object.defineProperty(AccessLevel.prototype, "level", {
+                            get: $util.oneOfGetter($oneOfFields = ["basic", "custom"]),
+                            set: $util.oneOfSetter($oneOfFields)
+                        });
+    
+                        /**
+                         * Creates a new AccessLevel instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessLevel=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.AccessLevel} AccessLevel instance
+                         */
+                        AccessLevel.create = function create(properties) {
+                            return new AccessLevel(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified AccessLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessLevel.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessLevel} message AccessLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        AccessLevel.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                writer.uint32(/* id 2, wireType 2 =*/18).string(message.title);
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
+                            if (message.basic != null && message.hasOwnProperty("basic"))
+                                $root.google.identity.accesscontextmanager.v1.BasicLevel.encode(message.basic, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                            if (message.custom != null && message.hasOwnProperty("custom"))
+                                $root.google.identity.accesscontextmanager.v1.CustomLevel.encode(message.custom, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                $root.google.protobuf.Timestamp.encode(message.createTime, writer.uint32(/* id 6, wireType 2 =*/50).fork()).ldelim();
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                $root.google.protobuf.Timestamp.encode(message.updateTime, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified AccessLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessLevel.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessLevel} message AccessLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        AccessLevel.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes an AccessLevel message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.AccessLevel} AccessLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        AccessLevel.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.AccessLevel();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.name = reader.string();
+                                    break;
+                                case 2:
+                                    message.title = reader.string();
+                                    break;
+                                case 3:
+                                    message.description = reader.string();
+                                    break;
+                                case 4:
+                                    message.basic = $root.google.identity.accesscontextmanager.v1.BasicLevel.decode(reader, reader.uint32());
+                                    break;
+                                case 5:
+                                    message.custom = $root.google.identity.accesscontextmanager.v1.CustomLevel.decode(reader, reader.uint32());
+                                    break;
+                                case 6:
+                                    message.createTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 7:
+                                    message.updateTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes an AccessLevel message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.AccessLevel} AccessLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        AccessLevel.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies an AccessLevel message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        AccessLevel.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            var properties = {};
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                if (!$util.isString(message.name))
+                                    return "name: string expected";
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                if (!$util.isString(message.title))
+                                    return "title: string expected";
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                if (!$util.isString(message.description))
+                                    return "description: string expected";
+                            if (message.basic != null && message.hasOwnProperty("basic")) {
+                                properties.level = 1;
+                                {
+                                    var error = $root.google.identity.accesscontextmanager.v1.BasicLevel.verify(message.basic);
+                                    if (error)
+                                        return "basic." + error;
+                                }
+                            }
+                            if (message.custom != null && message.hasOwnProperty("custom")) {
+                                if (properties.level === 1)
+                                    return "level: multiple values";
+                                properties.level = 1;
+                                {
+                                    var error = $root.google.identity.accesscontextmanager.v1.CustomLevel.verify(message.custom);
+                                    if (error)
+                                        return "custom." + error;
+                                }
+                            }
+                            if (message.createTime != null && message.hasOwnProperty("createTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.createTime);
+                                if (error)
+                                    return "createTime." + error;
+                            }
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.updateTime);
+                                if (error)
+                                    return "updateTime." + error;
+                            }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates an AccessLevel message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.AccessLevel} AccessLevel
+                         */
+                        AccessLevel.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.AccessLevel)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.AccessLevel();
+                            if (object.name != null)
+                                message.name = String(object.name);
+                            if (object.title != null)
+                                message.title = String(object.title);
+                            if (object.description != null)
+                                message.description = String(object.description);
+                            if (object.basic != null) {
+                                if (typeof object.basic !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessLevel.basic: object expected");
+                                message.basic = $root.google.identity.accesscontextmanager.v1.BasicLevel.fromObject(object.basic);
+                            }
+                            if (object.custom != null) {
+                                if (typeof object.custom !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessLevel.custom: object expected");
+                                message.custom = $root.google.identity.accesscontextmanager.v1.CustomLevel.fromObject(object.custom);
+                            }
+                            if (object.createTime != null) {
+                                if (typeof object.createTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessLevel.createTime: object expected");
+                                message.createTime = $root.google.protobuf.Timestamp.fromObject(object.createTime);
+                            }
+                            if (object.updateTime != null) {
+                                if (typeof object.updateTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessLevel.updateTime: object expected");
+                                message.updateTime = $root.google.protobuf.Timestamp.fromObject(object.updateTime);
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from an AccessLevel message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.AccessLevel} message AccessLevel
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        AccessLevel.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults) {
+                                object.name = "";
+                                object.title = "";
+                                object.description = "";
+                                object.createTime = null;
+                                object.updateTime = null;
+                            }
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                object.name = message.name;
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                object.title = message.title;
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                object.description = message.description;
+                            if (message.basic != null && message.hasOwnProperty("basic")) {
+                                object.basic = $root.google.identity.accesscontextmanager.v1.BasicLevel.toObject(message.basic, options);
+                                if (options.oneofs)
+                                    object.level = "basic";
+                            }
+                            if (message.custom != null && message.hasOwnProperty("custom")) {
+                                object.custom = $root.google.identity.accesscontextmanager.v1.CustomLevel.toObject(message.custom, options);
+                                if (options.oneofs)
+                                    object.level = "custom";
+                            }
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                object.createTime = $root.google.protobuf.Timestamp.toObject(message.createTime, options);
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                object.updateTime = $root.google.protobuf.Timestamp.toObject(message.updateTime, options);
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this AccessLevel to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.AccessLevel
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        AccessLevel.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return AccessLevel;
+                    })();
+    
+                    v1.BasicLevel = (function() {
+    
+                        /**
+                         * Properties of a BasicLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IBasicLevel
+                         * @property {Array.<google.identity.accesscontextmanager.v1.ICondition>|null} [conditions] BasicLevel conditions
+                         * @property {google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction|null} [combiningFunction] BasicLevel combiningFunction
+                         */
+    
+                        /**
+                         * Constructs a new BasicLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a BasicLevel.
+                         * @implements IBasicLevel
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IBasicLevel=} [properties] Properties to set
+                         */
+                        function BasicLevel(properties) {
+                            this.conditions = [];
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * BasicLevel conditions.
+                         * @member {Array.<google.identity.accesscontextmanager.v1.ICondition>} conditions
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @instance
+                         */
+                        BasicLevel.prototype.conditions = $util.emptyArray;
+    
+                        /**
+                         * BasicLevel combiningFunction.
+                         * @member {google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction} combiningFunction
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @instance
+                         */
+                        BasicLevel.prototype.combiningFunction = 0;
+    
+                        /**
+                         * Creates a new BasicLevel instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IBasicLevel=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.BasicLevel} BasicLevel instance
+                         */
+                        BasicLevel.create = function create(properties) {
+                            return new BasicLevel(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified BasicLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.BasicLevel.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IBasicLevel} message BasicLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        BasicLevel.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.conditions != null && message.conditions.length)
+                                for (var i = 0; i < message.conditions.length; ++i)
+                                    $root.google.identity.accesscontextmanager.v1.Condition.encode(message.conditions[i], writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                            if (message.combiningFunction != null && message.hasOwnProperty("combiningFunction"))
+                                writer.uint32(/* id 2, wireType 0 =*/16).int32(message.combiningFunction);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified BasicLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.BasicLevel.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IBasicLevel} message BasicLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        BasicLevel.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a BasicLevel message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.BasicLevel} BasicLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        BasicLevel.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.BasicLevel();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    if (!(message.conditions && message.conditions.length))
+                                        message.conditions = [];
+                                    message.conditions.push($root.google.identity.accesscontextmanager.v1.Condition.decode(reader, reader.uint32()));
+                                    break;
+                                case 2:
+                                    message.combiningFunction = reader.int32();
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a BasicLevel message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.BasicLevel} BasicLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        BasicLevel.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a BasicLevel message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        BasicLevel.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.conditions != null && message.hasOwnProperty("conditions")) {
+                                if (!Array.isArray(message.conditions))
+                                    return "conditions: array expected";
+                                for (var i = 0; i < message.conditions.length; ++i) {
+                                    var error = $root.google.identity.accesscontextmanager.v1.Condition.verify(message.conditions[i]);
+                                    if (error)
+                                        return "conditions." + error;
+                                }
+                            }
+                            if (message.combiningFunction != null && message.hasOwnProperty("combiningFunction"))
+                                switch (message.combiningFunction) {
+                                default:
+                                    return "combiningFunction: enum value expected";
+                                case 0:
+                                case 1:
+                                    break;
+                                }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a BasicLevel message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.BasicLevel} BasicLevel
+                         */
+                        BasicLevel.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.BasicLevel)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.BasicLevel();
+                            if (object.conditions) {
+                                if (!Array.isArray(object.conditions))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.BasicLevel.conditions: array expected");
+                                message.conditions = [];
+                                for (var i = 0; i < object.conditions.length; ++i) {
+                                    if (typeof object.conditions[i] !== "object")
+                                        throw TypeError(".google.identity.accesscontextmanager.v1.BasicLevel.conditions: object expected");
+                                    message.conditions[i] = $root.google.identity.accesscontextmanager.v1.Condition.fromObject(object.conditions[i]);
+                                }
+                            }
+                            switch (object.combiningFunction) {
+                            case "AND":
+                            case 0:
+                                message.combiningFunction = 0;
+                                break;
+                            case "OR":
+                            case 1:
+                                message.combiningFunction = 1;
+                                break;
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a BasicLevel message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.BasicLevel} message BasicLevel
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        BasicLevel.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.arrays || options.defaults)
+                                object.conditions = [];
+                            if (options.defaults)
+                                object.combiningFunction = options.enums === String ? "AND" : 0;
+                            if (message.conditions && message.conditions.length) {
+                                object.conditions = [];
+                                for (var j = 0; j < message.conditions.length; ++j)
+                                    object.conditions[j] = $root.google.identity.accesscontextmanager.v1.Condition.toObject(message.conditions[j], options);
+                            }
+                            if (message.combiningFunction != null && message.hasOwnProperty("combiningFunction"))
+                                object.combiningFunction = options.enums === String ? $root.google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction[message.combiningFunction] : message.combiningFunction;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this BasicLevel to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.BasicLevel
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        BasicLevel.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        /**
+                         * ConditionCombiningFunction enum.
+                         * @name google.identity.accesscontextmanager.v1.BasicLevel.ConditionCombiningFunction
+                         * @enum {string}
+                         * @property {number} AND=0 AND value
+                         * @property {number} OR=1 OR value
+                         */
+                        BasicLevel.ConditionCombiningFunction = (function() {
+                            var valuesById = {}, values = Object.create(valuesById);
+                            values[valuesById[0] = "AND"] = 0;
+                            values[valuesById[1] = "OR"] = 1;
+                            return values;
+                        })();
+    
+                        return BasicLevel;
+                    })();
+    
+                    v1.Condition = (function() {
+    
+                        /**
+                         * Properties of a Condition.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface ICondition
+                         * @property {Array.<string>|null} [ipSubnetworks] Condition ipSubnetworks
+                         * @property {google.identity.accesscontextmanager.v1.IDevicePolicy|null} [devicePolicy] Condition devicePolicy
+                         * @property {Array.<string>|null} [requiredAccessLevels] Condition requiredAccessLevels
+                         * @property {boolean|null} [negate] Condition negate
+                         * @property {Array.<string>|null} [members] Condition members
+                         * @property {Array.<string>|null} [regions] Condition regions
+                         */
+    
+                        /**
+                         * Constructs a new Condition.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a Condition.
+                         * @implements ICondition
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.ICondition=} [properties] Properties to set
+                         */
+                        function Condition(properties) {
+                            this.ipSubnetworks = [];
+                            this.requiredAccessLevels = [];
+                            this.members = [];
+                            this.regions = [];
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * Condition ipSubnetworks.
+                         * @member {Array.<string>} ipSubnetworks
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.ipSubnetworks = $util.emptyArray;
+    
+                        /**
+                         * Condition devicePolicy.
+                         * @member {google.identity.accesscontextmanager.v1.IDevicePolicy|null|undefined} devicePolicy
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.devicePolicy = null;
+    
+                        /**
+                         * Condition requiredAccessLevels.
+                         * @member {Array.<string>} requiredAccessLevels
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.requiredAccessLevels = $util.emptyArray;
+    
+                        /**
+                         * Condition negate.
+                         * @member {boolean} negate
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.negate = false;
+    
+                        /**
+                         * Condition members.
+                         * @member {Array.<string>} members
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.members = $util.emptyArray;
+    
+                        /**
+                         * Condition regions.
+                         * @member {Array.<string>} regions
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         */
+                        Condition.prototype.regions = $util.emptyArray;
+    
+                        /**
+                         * Creates a new Condition instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICondition=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.Condition} Condition instance
+                         */
+                        Condition.create = function create(properties) {
+                            return new Condition(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified Condition message. Does not implicitly {@link google.identity.accesscontextmanager.v1.Condition.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICondition} message Condition message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        Condition.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.ipSubnetworks != null && message.ipSubnetworks.length)
+                                for (var i = 0; i < message.ipSubnetworks.length; ++i)
+                                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.ipSubnetworks[i]);
+                            if (message.devicePolicy != null && message.hasOwnProperty("devicePolicy"))
+                                $root.google.identity.accesscontextmanager.v1.DevicePolicy.encode(message.devicePolicy, writer.uint32(/* id 2, wireType 2 =*/18).fork()).ldelim();
+                            if (message.requiredAccessLevels != null && message.requiredAccessLevels.length)
+                                for (var i = 0; i < message.requiredAccessLevels.length; ++i)
+                                    writer.uint32(/* id 3, wireType 2 =*/26).string(message.requiredAccessLevels[i]);
+                            if (message.negate != null && message.hasOwnProperty("negate"))
+                                writer.uint32(/* id 5, wireType 0 =*/40).bool(message.negate);
+                            if (message.members != null && message.members.length)
+                                for (var i = 0; i < message.members.length; ++i)
+                                    writer.uint32(/* id 6, wireType 2 =*/50).string(message.members[i]);
+                            if (message.regions != null && message.regions.length)
+                                for (var i = 0; i < message.regions.length; ++i)
+                                    writer.uint32(/* id 7, wireType 2 =*/58).string(message.regions[i]);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified Condition message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.Condition.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICondition} message Condition message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        Condition.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a Condition message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.Condition} Condition
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        Condition.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.Condition();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    if (!(message.ipSubnetworks && message.ipSubnetworks.length))
+                                        message.ipSubnetworks = [];
+                                    message.ipSubnetworks.push(reader.string());
+                                    break;
+                                case 2:
+                                    message.devicePolicy = $root.google.identity.accesscontextmanager.v1.DevicePolicy.decode(reader, reader.uint32());
+                                    break;
+                                case 3:
+                                    if (!(message.requiredAccessLevels && message.requiredAccessLevels.length))
+                                        message.requiredAccessLevels = [];
+                                    message.requiredAccessLevels.push(reader.string());
+                                    break;
+                                case 5:
+                                    message.negate = reader.bool();
+                                    break;
+                                case 6:
+                                    if (!(message.members && message.members.length))
+                                        message.members = [];
+                                    message.members.push(reader.string());
+                                    break;
+                                case 7:
+                                    if (!(message.regions && message.regions.length))
+                                        message.regions = [];
+                                    message.regions.push(reader.string());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a Condition message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.Condition} Condition
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        Condition.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a Condition message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        Condition.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.ipSubnetworks != null && message.hasOwnProperty("ipSubnetworks")) {
+                                if (!Array.isArray(message.ipSubnetworks))
+                                    return "ipSubnetworks: array expected";
+                                for (var i = 0; i < message.ipSubnetworks.length; ++i)
+                                    if (!$util.isString(message.ipSubnetworks[i]))
+                                        return "ipSubnetworks: string[] expected";
+                            }
+                            if (message.devicePolicy != null && message.hasOwnProperty("devicePolicy")) {
+                                var error = $root.google.identity.accesscontextmanager.v1.DevicePolicy.verify(message.devicePolicy);
+                                if (error)
+                                    return "devicePolicy." + error;
+                            }
+                            if (message.requiredAccessLevels != null && message.hasOwnProperty("requiredAccessLevels")) {
+                                if (!Array.isArray(message.requiredAccessLevels))
+                                    return "requiredAccessLevels: array expected";
+                                for (var i = 0; i < message.requiredAccessLevels.length; ++i)
+                                    if (!$util.isString(message.requiredAccessLevels[i]))
+                                        return "requiredAccessLevels: string[] expected";
+                            }
+                            if (message.negate != null && message.hasOwnProperty("negate"))
+                                if (typeof message.negate !== "boolean")
+                                    return "negate: boolean expected";
+                            if (message.members != null && message.hasOwnProperty("members")) {
+                                if (!Array.isArray(message.members))
+                                    return "members: array expected";
+                                for (var i = 0; i < message.members.length; ++i)
+                                    if (!$util.isString(message.members[i]))
+                                        return "members: string[] expected";
+                            }
+                            if (message.regions != null && message.hasOwnProperty("regions")) {
+                                if (!Array.isArray(message.regions))
+                                    return "regions: array expected";
+                                for (var i = 0; i < message.regions.length; ++i)
+                                    if (!$util.isString(message.regions[i]))
+                                        return "regions: string[] expected";
+                            }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a Condition message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.Condition} Condition
+                         */
+                        Condition.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.Condition)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.Condition();
+                            if (object.ipSubnetworks) {
+                                if (!Array.isArray(object.ipSubnetworks))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.Condition.ipSubnetworks: array expected");
+                                message.ipSubnetworks = [];
+                                for (var i = 0; i < object.ipSubnetworks.length; ++i)
+                                    message.ipSubnetworks[i] = String(object.ipSubnetworks[i]);
+                            }
+                            if (object.devicePolicy != null) {
+                                if (typeof object.devicePolicy !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.Condition.devicePolicy: object expected");
+                                message.devicePolicy = $root.google.identity.accesscontextmanager.v1.DevicePolicy.fromObject(object.devicePolicy);
+                            }
+                            if (object.requiredAccessLevels) {
+                                if (!Array.isArray(object.requiredAccessLevels))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.Condition.requiredAccessLevels: array expected");
+                                message.requiredAccessLevels = [];
+                                for (var i = 0; i < object.requiredAccessLevels.length; ++i)
+                                    message.requiredAccessLevels[i] = String(object.requiredAccessLevels[i]);
+                            }
+                            if (object.negate != null)
+                                message.negate = Boolean(object.negate);
+                            if (object.members) {
+                                if (!Array.isArray(object.members))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.Condition.members: array expected");
+                                message.members = [];
+                                for (var i = 0; i < object.members.length; ++i)
+                                    message.members[i] = String(object.members[i]);
+                            }
+                            if (object.regions) {
+                                if (!Array.isArray(object.regions))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.Condition.regions: array expected");
+                                message.regions = [];
+                                for (var i = 0; i < object.regions.length; ++i)
+                                    message.regions[i] = String(object.regions[i]);
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a Condition message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.Condition} message Condition
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        Condition.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.arrays || options.defaults) {
+                                object.ipSubnetworks = [];
+                                object.requiredAccessLevels = [];
+                                object.members = [];
+                                object.regions = [];
+                            }
+                            if (options.defaults) {
+                                object.devicePolicy = null;
+                                object.negate = false;
+                            }
+                            if (message.ipSubnetworks && message.ipSubnetworks.length) {
+                                object.ipSubnetworks = [];
+                                for (var j = 0; j < message.ipSubnetworks.length; ++j)
+                                    object.ipSubnetworks[j] = message.ipSubnetworks[j];
+                            }
+                            if (message.devicePolicy != null && message.hasOwnProperty("devicePolicy"))
+                                object.devicePolicy = $root.google.identity.accesscontextmanager.v1.DevicePolicy.toObject(message.devicePolicy, options);
+                            if (message.requiredAccessLevels && message.requiredAccessLevels.length) {
+                                object.requiredAccessLevels = [];
+                                for (var j = 0; j < message.requiredAccessLevels.length; ++j)
+                                    object.requiredAccessLevels[j] = message.requiredAccessLevels[j];
+                            }
+                            if (message.negate != null && message.hasOwnProperty("negate"))
+                                object.negate = message.negate;
+                            if (message.members && message.members.length) {
+                                object.members = [];
+                                for (var j = 0; j < message.members.length; ++j)
+                                    object.members[j] = message.members[j];
+                            }
+                            if (message.regions && message.regions.length) {
+                                object.regions = [];
+                                for (var j = 0; j < message.regions.length; ++j)
+                                    object.regions[j] = message.regions[j];
+                            }
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this Condition to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.Condition
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        Condition.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return Condition;
+                    })();
+    
+                    v1.CustomLevel = (function() {
+    
+                        /**
+                         * Properties of a CustomLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface ICustomLevel
+                         * @property {google.type.IExpr|null} [expr] CustomLevel expr
+                         */
+    
+                        /**
+                         * Constructs a new CustomLevel.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a CustomLevel.
+                         * @implements ICustomLevel
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.ICustomLevel=} [properties] Properties to set
+                         */
+                        function CustomLevel(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * CustomLevel expr.
+                         * @member {google.type.IExpr|null|undefined} expr
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @instance
+                         */
+                        CustomLevel.prototype.expr = null;
+    
+                        /**
+                         * Creates a new CustomLevel instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICustomLevel=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.CustomLevel} CustomLevel instance
+                         */
+                        CustomLevel.create = function create(properties) {
+                            return new CustomLevel(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified CustomLevel message. Does not implicitly {@link google.identity.accesscontextmanager.v1.CustomLevel.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICustomLevel} message CustomLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        CustomLevel.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.expr != null && message.hasOwnProperty("expr"))
+                                $root.google.type.Expr.encode(message.expr, writer.uint32(/* id 1, wireType 2 =*/10).fork()).ldelim();
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified CustomLevel message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.CustomLevel.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ICustomLevel} message CustomLevel message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        CustomLevel.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a CustomLevel message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.CustomLevel} CustomLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        CustomLevel.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.CustomLevel();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.expr = $root.google.type.Expr.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a CustomLevel message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.CustomLevel} CustomLevel
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        CustomLevel.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a CustomLevel message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        CustomLevel.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.expr != null && message.hasOwnProperty("expr")) {
+                                var error = $root.google.type.Expr.verify(message.expr);
+                                if (error)
+                                    return "expr." + error;
+                            }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a CustomLevel message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.CustomLevel} CustomLevel
+                         */
+                        CustomLevel.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.CustomLevel)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.CustomLevel();
+                            if (object.expr != null) {
+                                if (typeof object.expr !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.CustomLevel.expr: object expected");
+                                message.expr = $root.google.type.Expr.fromObject(object.expr);
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a CustomLevel message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.CustomLevel} message CustomLevel
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        CustomLevel.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults)
+                                object.expr = null;
+                            if (message.expr != null && message.hasOwnProperty("expr"))
+                                object.expr = $root.google.type.Expr.toObject(message.expr, options);
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this CustomLevel to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.CustomLevel
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        CustomLevel.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return CustomLevel;
+                    })();
+    
+                    v1.DevicePolicy = (function() {
+    
+                        /**
+                         * Properties of a DevicePolicy.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IDevicePolicy
+                         * @property {boolean|null} [requireScreenlock] DevicePolicy requireScreenlock
+                         * @property {Array.<google.identity.accesscontextmanager.type.DeviceEncryptionStatus>|null} [allowedEncryptionStatuses] DevicePolicy allowedEncryptionStatuses
+                         * @property {Array.<google.identity.accesscontextmanager.v1.IOsConstraint>|null} [osConstraints] DevicePolicy osConstraints
+                         * @property {Array.<google.identity.accesscontextmanager.type.DeviceManagementLevel>|null} [allowedDeviceManagementLevels] DevicePolicy allowedDeviceManagementLevels
+                         * @property {boolean|null} [requireAdminApproval] DevicePolicy requireAdminApproval
+                         * @property {boolean|null} [requireCorpOwned] DevicePolicy requireCorpOwned
+                         */
+    
+                        /**
+                         * Constructs a new DevicePolicy.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a DevicePolicy.
+                         * @implements IDevicePolicy
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IDevicePolicy=} [properties] Properties to set
+                         */
+                        function DevicePolicy(properties) {
+                            this.allowedEncryptionStatuses = [];
+                            this.osConstraints = [];
+                            this.allowedDeviceManagementLevels = [];
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * DevicePolicy requireScreenlock.
+                         * @member {boolean} requireScreenlock
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.requireScreenlock = false;
+    
+                        /**
+                         * DevicePolicy allowedEncryptionStatuses.
+                         * @member {Array.<google.identity.accesscontextmanager.type.DeviceEncryptionStatus>} allowedEncryptionStatuses
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.allowedEncryptionStatuses = $util.emptyArray;
+    
+                        /**
+                         * DevicePolicy osConstraints.
+                         * @member {Array.<google.identity.accesscontextmanager.v1.IOsConstraint>} osConstraints
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.osConstraints = $util.emptyArray;
+    
+                        /**
+                         * DevicePolicy allowedDeviceManagementLevels.
+                         * @member {Array.<google.identity.accesscontextmanager.type.DeviceManagementLevel>} allowedDeviceManagementLevels
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.allowedDeviceManagementLevels = $util.emptyArray;
+    
+                        /**
+                         * DevicePolicy requireAdminApproval.
+                         * @member {boolean} requireAdminApproval
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.requireAdminApproval = false;
+    
+                        /**
+                         * DevicePolicy requireCorpOwned.
+                         * @member {boolean} requireCorpOwned
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         */
+                        DevicePolicy.prototype.requireCorpOwned = false;
+    
+                        /**
+                         * Creates a new DevicePolicy instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IDevicePolicy=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.DevicePolicy} DevicePolicy instance
+                         */
+                        DevicePolicy.create = function create(properties) {
+                            return new DevicePolicy(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified DevicePolicy message. Does not implicitly {@link google.identity.accesscontextmanager.v1.DevicePolicy.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IDevicePolicy} message DevicePolicy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        DevicePolicy.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.requireScreenlock != null && message.hasOwnProperty("requireScreenlock"))
+                                writer.uint32(/* id 1, wireType 0 =*/8).bool(message.requireScreenlock);
+                            if (message.allowedEncryptionStatuses != null && message.allowedEncryptionStatuses.length) {
+                                writer.uint32(/* id 2, wireType 2 =*/18).fork();
+                                for (var i = 0; i < message.allowedEncryptionStatuses.length; ++i)
+                                    writer.int32(message.allowedEncryptionStatuses[i]);
+                                writer.ldelim();
+                            }
+                            if (message.osConstraints != null && message.osConstraints.length)
+                                for (var i = 0; i < message.osConstraints.length; ++i)
+                                    $root.google.identity.accesscontextmanager.v1.OsConstraint.encode(message.osConstraints[i], writer.uint32(/* id 3, wireType 2 =*/26).fork()).ldelim();
+                            if (message.allowedDeviceManagementLevels != null && message.allowedDeviceManagementLevels.length) {
+                                writer.uint32(/* id 6, wireType 2 =*/50).fork();
+                                for (var i = 0; i < message.allowedDeviceManagementLevels.length; ++i)
+                                    writer.int32(message.allowedDeviceManagementLevels[i]);
+                                writer.ldelim();
+                            }
+                            if (message.requireAdminApproval != null && message.hasOwnProperty("requireAdminApproval"))
+                                writer.uint32(/* id 7, wireType 0 =*/56).bool(message.requireAdminApproval);
+                            if (message.requireCorpOwned != null && message.hasOwnProperty("requireCorpOwned"))
+                                writer.uint32(/* id 8, wireType 0 =*/64).bool(message.requireCorpOwned);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified DevicePolicy message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.DevicePolicy.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IDevicePolicy} message DevicePolicy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        DevicePolicy.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a DevicePolicy message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.DevicePolicy} DevicePolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        DevicePolicy.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.DevicePolicy();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.requireScreenlock = reader.bool();
+                                    break;
+                                case 2:
+                                    if (!(message.allowedEncryptionStatuses && message.allowedEncryptionStatuses.length))
+                                        message.allowedEncryptionStatuses = [];
+                                    if ((tag & 7) === 2) {
+                                        var end2 = reader.uint32() + reader.pos;
+                                        while (reader.pos < end2)
+                                            message.allowedEncryptionStatuses.push(reader.int32());
+                                    } else
+                                        message.allowedEncryptionStatuses.push(reader.int32());
+                                    break;
+                                case 3:
+                                    if (!(message.osConstraints && message.osConstraints.length))
+                                        message.osConstraints = [];
+                                    message.osConstraints.push($root.google.identity.accesscontextmanager.v1.OsConstraint.decode(reader, reader.uint32()));
+                                    break;
+                                case 6:
+                                    if (!(message.allowedDeviceManagementLevels && message.allowedDeviceManagementLevels.length))
+                                        message.allowedDeviceManagementLevels = [];
+                                    if ((tag & 7) === 2) {
+                                        var end2 = reader.uint32() + reader.pos;
+                                        while (reader.pos < end2)
+                                            message.allowedDeviceManagementLevels.push(reader.int32());
+                                    } else
+                                        message.allowedDeviceManagementLevels.push(reader.int32());
+                                    break;
+                                case 7:
+                                    message.requireAdminApproval = reader.bool();
+                                    break;
+                                case 8:
+                                    message.requireCorpOwned = reader.bool();
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a DevicePolicy message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.DevicePolicy} DevicePolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        DevicePolicy.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a DevicePolicy message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        DevicePolicy.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.requireScreenlock != null && message.hasOwnProperty("requireScreenlock"))
+                                if (typeof message.requireScreenlock !== "boolean")
+                                    return "requireScreenlock: boolean expected";
+                            if (message.allowedEncryptionStatuses != null && message.hasOwnProperty("allowedEncryptionStatuses")) {
+                                if (!Array.isArray(message.allowedEncryptionStatuses))
+                                    return "allowedEncryptionStatuses: array expected";
+                                for (var i = 0; i < message.allowedEncryptionStatuses.length; ++i)
+                                    switch (message.allowedEncryptionStatuses[i]) {
+                                    default:
+                                        return "allowedEncryptionStatuses: enum value[] expected";
+                                    case 0:
+                                    case 1:
+                                    case 2:
+                                    case 3:
+                                        break;
+                                    }
+                            }
+                            if (message.osConstraints != null && message.hasOwnProperty("osConstraints")) {
+                                if (!Array.isArray(message.osConstraints))
+                                    return "osConstraints: array expected";
+                                for (var i = 0; i < message.osConstraints.length; ++i) {
+                                    var error = $root.google.identity.accesscontextmanager.v1.OsConstraint.verify(message.osConstraints[i]);
+                                    if (error)
+                                        return "osConstraints." + error;
+                                }
+                            }
+                            if (message.allowedDeviceManagementLevels != null && message.hasOwnProperty("allowedDeviceManagementLevels")) {
+                                if (!Array.isArray(message.allowedDeviceManagementLevels))
+                                    return "allowedDeviceManagementLevels: array expected";
+                                for (var i = 0; i < message.allowedDeviceManagementLevels.length; ++i)
+                                    switch (message.allowedDeviceManagementLevels[i]) {
+                                    default:
+                                        return "allowedDeviceManagementLevels: enum value[] expected";
+                                    case 0:
+                                    case 1:
+                                    case 2:
+                                    case 3:
+                                        break;
+                                    }
+                            }
+                            if (message.requireAdminApproval != null && message.hasOwnProperty("requireAdminApproval"))
+                                if (typeof message.requireAdminApproval !== "boolean")
+                                    return "requireAdminApproval: boolean expected";
+                            if (message.requireCorpOwned != null && message.hasOwnProperty("requireCorpOwned"))
+                                if (typeof message.requireCorpOwned !== "boolean")
+                                    return "requireCorpOwned: boolean expected";
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a DevicePolicy message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.DevicePolicy} DevicePolicy
+                         */
+                        DevicePolicy.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.DevicePolicy)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.DevicePolicy();
+                            if (object.requireScreenlock != null)
+                                message.requireScreenlock = Boolean(object.requireScreenlock);
+                            if (object.allowedEncryptionStatuses) {
+                                if (!Array.isArray(object.allowedEncryptionStatuses))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.DevicePolicy.allowedEncryptionStatuses: array expected");
+                                message.allowedEncryptionStatuses = [];
+                                for (var i = 0; i < object.allowedEncryptionStatuses.length; ++i)
+                                    switch (object.allowedEncryptionStatuses[i]) {
+                                    default:
+                                    case "ENCRYPTION_UNSPECIFIED":
+                                    case 0:
+                                        message.allowedEncryptionStatuses[i] = 0;
+                                        break;
+                                    case "ENCRYPTION_UNSUPPORTED":
+                                    case 1:
+                                        message.allowedEncryptionStatuses[i] = 1;
+                                        break;
+                                    case "UNENCRYPTED":
+                                    case 2:
+                                        message.allowedEncryptionStatuses[i] = 2;
+                                        break;
+                                    case "ENCRYPTED":
+                                    case 3:
+                                        message.allowedEncryptionStatuses[i] = 3;
+                                        break;
+                                    }
+                            }
+                            if (object.osConstraints) {
+                                if (!Array.isArray(object.osConstraints))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.DevicePolicy.osConstraints: array expected");
+                                message.osConstraints = [];
+                                for (var i = 0; i < object.osConstraints.length; ++i) {
+                                    if (typeof object.osConstraints[i] !== "object")
+                                        throw TypeError(".google.identity.accesscontextmanager.v1.DevicePolicy.osConstraints: object expected");
+                                    message.osConstraints[i] = $root.google.identity.accesscontextmanager.v1.OsConstraint.fromObject(object.osConstraints[i]);
+                                }
+                            }
+                            if (object.allowedDeviceManagementLevels) {
+                                if (!Array.isArray(object.allowedDeviceManagementLevels))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.DevicePolicy.allowedDeviceManagementLevels: array expected");
+                                message.allowedDeviceManagementLevels = [];
+                                for (var i = 0; i < object.allowedDeviceManagementLevels.length; ++i)
+                                    switch (object.allowedDeviceManagementLevels[i]) {
+                                    default:
+                                    case "MANAGEMENT_UNSPECIFIED":
+                                    case 0:
+                                        message.allowedDeviceManagementLevels[i] = 0;
+                                        break;
+                                    case "NONE":
+                                    case 1:
+                                        message.allowedDeviceManagementLevels[i] = 1;
+                                        break;
+                                    case "BASIC":
+                                    case 2:
+                                        message.allowedDeviceManagementLevels[i] = 2;
+                                        break;
+                                    case "COMPLETE":
+                                    case 3:
+                                        message.allowedDeviceManagementLevels[i] = 3;
+                                        break;
+                                    }
+                            }
+                            if (object.requireAdminApproval != null)
+                                message.requireAdminApproval = Boolean(object.requireAdminApproval);
+                            if (object.requireCorpOwned != null)
+                                message.requireCorpOwned = Boolean(object.requireCorpOwned);
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a DevicePolicy message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.DevicePolicy} message DevicePolicy
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        DevicePolicy.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.arrays || options.defaults) {
+                                object.allowedEncryptionStatuses = [];
+                                object.osConstraints = [];
+                                object.allowedDeviceManagementLevels = [];
+                            }
+                            if (options.defaults) {
+                                object.requireScreenlock = false;
+                                object.requireAdminApproval = false;
+                                object.requireCorpOwned = false;
+                            }
+                            if (message.requireScreenlock != null && message.hasOwnProperty("requireScreenlock"))
+                                object.requireScreenlock = message.requireScreenlock;
+                            if (message.allowedEncryptionStatuses && message.allowedEncryptionStatuses.length) {
+                                object.allowedEncryptionStatuses = [];
+                                for (var j = 0; j < message.allowedEncryptionStatuses.length; ++j)
+                                    object.allowedEncryptionStatuses[j] = options.enums === String ? $root.google.identity.accesscontextmanager.type.DeviceEncryptionStatus[message.allowedEncryptionStatuses[j]] : message.allowedEncryptionStatuses[j];
+                            }
+                            if (message.osConstraints && message.osConstraints.length) {
+                                object.osConstraints = [];
+                                for (var j = 0; j < message.osConstraints.length; ++j)
+                                    object.osConstraints[j] = $root.google.identity.accesscontextmanager.v1.OsConstraint.toObject(message.osConstraints[j], options);
+                            }
+                            if (message.allowedDeviceManagementLevels && message.allowedDeviceManagementLevels.length) {
+                                object.allowedDeviceManagementLevels = [];
+                                for (var j = 0; j < message.allowedDeviceManagementLevels.length; ++j)
+                                    object.allowedDeviceManagementLevels[j] = options.enums === String ? $root.google.identity.accesscontextmanager.type.DeviceManagementLevel[message.allowedDeviceManagementLevels[j]] : message.allowedDeviceManagementLevels[j];
+                            }
+                            if (message.requireAdminApproval != null && message.hasOwnProperty("requireAdminApproval"))
+                                object.requireAdminApproval = message.requireAdminApproval;
+                            if (message.requireCorpOwned != null && message.hasOwnProperty("requireCorpOwned"))
+                                object.requireCorpOwned = message.requireCorpOwned;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this DevicePolicy to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.DevicePolicy
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        DevicePolicy.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return DevicePolicy;
+                    })();
+    
+                    v1.OsConstraint = (function() {
+    
+                        /**
+                         * Properties of an OsConstraint.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IOsConstraint
+                         * @property {google.identity.accesscontextmanager.type.OsType|null} [osType] OsConstraint osType
+                         * @property {string|null} [minimumVersion] OsConstraint minimumVersion
+                         * @property {boolean|null} [requireVerifiedChromeOs] OsConstraint requireVerifiedChromeOs
+                         */
+    
+                        /**
+                         * Constructs a new OsConstraint.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents an OsConstraint.
+                         * @implements IOsConstraint
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IOsConstraint=} [properties] Properties to set
+                         */
+                        function OsConstraint(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * OsConstraint osType.
+                         * @member {google.identity.accesscontextmanager.type.OsType} osType
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @instance
+                         */
+                        OsConstraint.prototype.osType = 0;
+    
+                        /**
+                         * OsConstraint minimumVersion.
+                         * @member {string} minimumVersion
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @instance
+                         */
+                        OsConstraint.prototype.minimumVersion = "";
+    
+                        /**
+                         * OsConstraint requireVerifiedChromeOs.
+                         * @member {boolean} requireVerifiedChromeOs
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @instance
+                         */
+                        OsConstraint.prototype.requireVerifiedChromeOs = false;
+    
+                        /**
+                         * Creates a new OsConstraint instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IOsConstraint=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.OsConstraint} OsConstraint instance
+                         */
+                        OsConstraint.create = function create(properties) {
+                            return new OsConstraint(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified OsConstraint message. Does not implicitly {@link google.identity.accesscontextmanager.v1.OsConstraint.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IOsConstraint} message OsConstraint message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        OsConstraint.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.osType != null && message.hasOwnProperty("osType"))
+                                writer.uint32(/* id 1, wireType 0 =*/8).int32(message.osType);
+                            if (message.minimumVersion != null && message.hasOwnProperty("minimumVersion"))
+                                writer.uint32(/* id 2, wireType 2 =*/18).string(message.minimumVersion);
+                            if (message.requireVerifiedChromeOs != null && message.hasOwnProperty("requireVerifiedChromeOs"))
+                                writer.uint32(/* id 3, wireType 0 =*/24).bool(message.requireVerifiedChromeOs);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified OsConstraint message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.OsConstraint.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IOsConstraint} message OsConstraint message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        OsConstraint.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes an OsConstraint message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.OsConstraint} OsConstraint
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        OsConstraint.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.OsConstraint();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.osType = reader.int32();
+                                    break;
+                                case 2:
+                                    message.minimumVersion = reader.string();
+                                    break;
+                                case 3:
+                                    message.requireVerifiedChromeOs = reader.bool();
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes an OsConstraint message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.OsConstraint} OsConstraint
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        OsConstraint.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies an OsConstraint message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        OsConstraint.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.osType != null && message.hasOwnProperty("osType"))
+                                switch (message.osType) {
+                                default:
+                                    return "osType: enum value expected";
+                                case 0:
+                                case 1:
+                                case 2:
+                                case 3:
+                                case 6:
+                                case 4:
+                                case 5:
+                                    break;
+                                }
+                            if (message.minimumVersion != null && message.hasOwnProperty("minimumVersion"))
+                                if (!$util.isString(message.minimumVersion))
+                                    return "minimumVersion: string expected";
+                            if (message.requireVerifiedChromeOs != null && message.hasOwnProperty("requireVerifiedChromeOs"))
+                                if (typeof message.requireVerifiedChromeOs !== "boolean")
+                                    return "requireVerifiedChromeOs: boolean expected";
+                            return null;
+                        };
+    
+                        /**
+                         * Creates an OsConstraint message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.OsConstraint} OsConstraint
+                         */
+                        OsConstraint.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.OsConstraint)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.OsConstraint();
+                            switch (object.osType) {
+                            case "OS_UNSPECIFIED":
+                            case 0:
+                                message.osType = 0;
+                                break;
+                            case "DESKTOP_MAC":
+                            case 1:
+                                message.osType = 1;
+                                break;
+                            case "DESKTOP_WINDOWS":
+                            case 2:
+                                message.osType = 2;
+                                break;
+                            case "DESKTOP_LINUX":
+                            case 3:
+                                message.osType = 3;
+                                break;
+                            case "DESKTOP_CHROME_OS":
+                            case 6:
+                                message.osType = 6;
+                                break;
+                            case "ANDROID":
+                            case 4:
+                                message.osType = 4;
+                                break;
+                            case "IOS":
+                            case 5:
+                                message.osType = 5;
+                                break;
+                            }
+                            if (object.minimumVersion != null)
+                                message.minimumVersion = String(object.minimumVersion);
+                            if (object.requireVerifiedChromeOs != null)
+                                message.requireVerifiedChromeOs = Boolean(object.requireVerifiedChromeOs);
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from an OsConstraint message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.OsConstraint} message OsConstraint
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        OsConstraint.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults) {
+                                object.osType = options.enums === String ? "OS_UNSPECIFIED" : 0;
+                                object.minimumVersion = "";
+                                object.requireVerifiedChromeOs = false;
+                            }
+                            if (message.osType != null && message.hasOwnProperty("osType"))
+                                object.osType = options.enums === String ? $root.google.identity.accesscontextmanager.type.OsType[message.osType] : message.osType;
+                            if (message.minimumVersion != null && message.hasOwnProperty("minimumVersion"))
+                                object.minimumVersion = message.minimumVersion;
+                            if (message.requireVerifiedChromeOs != null && message.hasOwnProperty("requireVerifiedChromeOs"))
+                                object.requireVerifiedChromeOs = message.requireVerifiedChromeOs;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this OsConstraint to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.OsConstraint
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        OsConstraint.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return OsConstraint;
+                    })();
+    
+                    v1.AccessPolicy = (function() {
+    
+                        /**
+                         * Properties of an AccessPolicy.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IAccessPolicy
+                         * @property {string|null} [name] AccessPolicy name
+                         * @property {string|null} [parent] AccessPolicy parent
+                         * @property {string|null} [title] AccessPolicy title
+                         * @property {google.protobuf.ITimestamp|null} [createTime] AccessPolicy createTime
+                         * @property {google.protobuf.ITimestamp|null} [updateTime] AccessPolicy updateTime
+                         * @property {string|null} [etag] AccessPolicy etag
+                         */
+    
+                        /**
+                         * Constructs a new AccessPolicy.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents an AccessPolicy.
+                         * @implements IAccessPolicy
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IAccessPolicy=} [properties] Properties to set
+                         */
+                        function AccessPolicy(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * AccessPolicy name.
+                         * @member {string} name
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.name = "";
+    
+                        /**
+                         * AccessPolicy parent.
+                         * @member {string} parent
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.parent = "";
+    
+                        /**
+                         * AccessPolicy title.
+                         * @member {string} title
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.title = "";
+    
+                        /**
+                         * AccessPolicy createTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} createTime
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.createTime = null;
+    
+                        /**
+                         * AccessPolicy updateTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} updateTime
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.updateTime = null;
+    
+                        /**
+                         * AccessPolicy etag.
+                         * @member {string} etag
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         */
+                        AccessPolicy.prototype.etag = "";
+    
+                        /**
+                         * Creates a new AccessPolicy instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessPolicy=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.AccessPolicy} AccessPolicy instance
+                         */
+                        AccessPolicy.create = function create(properties) {
+                            return new AccessPolicy(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified AccessPolicy message. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessPolicy.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessPolicy} message AccessPolicy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        AccessPolicy.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                            if (message.parent != null && message.hasOwnProperty("parent"))
+                                writer.uint32(/* id 2, wireType 2 =*/18).string(message.parent);
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                writer.uint32(/* id 3, wireType 2 =*/26).string(message.title);
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                $root.google.protobuf.Timestamp.encode(message.createTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                $root.google.protobuf.Timestamp.encode(message.updateTime, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                writer.uint32(/* id 6, wireType 2 =*/50).string(message.etag);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified AccessPolicy message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.AccessPolicy.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IAccessPolicy} message AccessPolicy message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        AccessPolicy.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes an AccessPolicy message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.AccessPolicy} AccessPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        AccessPolicy.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.AccessPolicy();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.name = reader.string();
+                                    break;
+                                case 2:
+                                    message.parent = reader.string();
+                                    break;
+                                case 3:
+                                    message.title = reader.string();
+                                    break;
+                                case 4:
+                                    message.createTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 5:
+                                    message.updateTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 6:
+                                    message.etag = reader.string();
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes an AccessPolicy message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.AccessPolicy} AccessPolicy
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        AccessPolicy.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies an AccessPolicy message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        AccessPolicy.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                if (!$util.isString(message.name))
+                                    return "name: string expected";
+                            if (message.parent != null && message.hasOwnProperty("parent"))
+                                if (!$util.isString(message.parent))
+                                    return "parent: string expected";
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                if (!$util.isString(message.title))
+                                    return "title: string expected";
+                            if (message.createTime != null && message.hasOwnProperty("createTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.createTime);
+                                if (error)
+                                    return "createTime." + error;
+                            }
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.updateTime);
+                                if (error)
+                                    return "updateTime." + error;
+                            }
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                if (!$util.isString(message.etag))
+                                    return "etag: string expected";
+                            return null;
+                        };
+    
+                        /**
+                         * Creates an AccessPolicy message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.AccessPolicy} AccessPolicy
+                         */
+                        AccessPolicy.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.AccessPolicy)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.AccessPolicy();
+                            if (object.name != null)
+                                message.name = String(object.name);
+                            if (object.parent != null)
+                                message.parent = String(object.parent);
+                            if (object.title != null)
+                                message.title = String(object.title);
+                            if (object.createTime != null) {
+                                if (typeof object.createTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessPolicy.createTime: object expected");
+                                message.createTime = $root.google.protobuf.Timestamp.fromObject(object.createTime);
+                            }
+                            if (object.updateTime != null) {
+                                if (typeof object.updateTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.AccessPolicy.updateTime: object expected");
+                                message.updateTime = $root.google.protobuf.Timestamp.fromObject(object.updateTime);
+                            }
+                            if (object.etag != null)
+                                message.etag = String(object.etag);
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from an AccessPolicy message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.AccessPolicy} message AccessPolicy
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        AccessPolicy.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults) {
+                                object.name = "";
+                                object.parent = "";
+                                object.title = "";
+                                object.createTime = null;
+                                object.updateTime = null;
+                                object.etag = "";
+                            }
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                object.name = message.name;
+                            if (message.parent != null && message.hasOwnProperty("parent"))
+                                object.parent = message.parent;
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                object.title = message.title;
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                object.createTime = $root.google.protobuf.Timestamp.toObject(message.createTime, options);
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                object.updateTime = $root.google.protobuf.Timestamp.toObject(message.updateTime, options);
+                            if (message.etag != null && message.hasOwnProperty("etag"))
+                                object.etag = message.etag;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this AccessPolicy to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.AccessPolicy
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        AccessPolicy.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        return AccessPolicy;
+                    })();
+    
+                    v1.ServicePerimeter = (function() {
+    
+                        /**
+                         * Properties of a ServicePerimeter.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IServicePerimeter
+                         * @property {string|null} [name] ServicePerimeter name
+                         * @property {string|null} [title] ServicePerimeter title
+                         * @property {string|null} [description] ServicePerimeter description
+                         * @property {google.protobuf.ITimestamp|null} [createTime] ServicePerimeter createTime
+                         * @property {google.protobuf.ITimestamp|null} [updateTime] ServicePerimeter updateTime
+                         * @property {google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType|null} [perimeterType] ServicePerimeter perimeterType
+                         * @property {google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null} [status] ServicePerimeter status
+                         * @property {google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null} [spec] ServicePerimeter spec
+                         * @property {boolean|null} [useExplicitDryRunSpec] ServicePerimeter useExplicitDryRunSpec
+                         */
+    
+                        /**
+                         * Constructs a new ServicePerimeter.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a ServicePerimeter.
+                         * @implements IServicePerimeter
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeter=} [properties] Properties to set
+                         */
+                        function ServicePerimeter(properties) {
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * ServicePerimeter name.
+                         * @member {string} name
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.name = "";
+    
+                        /**
+                         * ServicePerimeter title.
+                         * @member {string} title
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.title = "";
+    
+                        /**
+                         * ServicePerimeter description.
+                         * @member {string} description
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.description = "";
+    
+                        /**
+                         * ServicePerimeter createTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} createTime
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.createTime = null;
+    
+                        /**
+                         * ServicePerimeter updateTime.
+                         * @member {google.protobuf.ITimestamp|null|undefined} updateTime
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.updateTime = null;
+    
+                        /**
+                         * ServicePerimeter perimeterType.
+                         * @member {google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType} perimeterType
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.perimeterType = 0;
+    
+                        /**
+                         * ServicePerimeter status.
+                         * @member {google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null|undefined} status
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.status = null;
+    
+                        /**
+                         * ServicePerimeter spec.
+                         * @member {google.identity.accesscontextmanager.v1.IServicePerimeterConfig|null|undefined} spec
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.spec = null;
+    
+                        /**
+                         * ServicePerimeter useExplicitDryRunSpec.
+                         * @member {boolean} useExplicitDryRunSpec
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         */
+                        ServicePerimeter.prototype.useExplicitDryRunSpec = false;
+    
+                        /**
+                         * Creates a new ServicePerimeter instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeter=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeter} ServicePerimeter instance
+                         */
+                        ServicePerimeter.create = function create(properties) {
+                            return new ServicePerimeter(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified ServicePerimeter message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeter.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeter} message ServicePerimeter message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        ServicePerimeter.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                writer.uint32(/* id 1, wireType 2 =*/10).string(message.name);
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                writer.uint32(/* id 2, wireType 2 =*/18).string(message.title);
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                writer.uint32(/* id 3, wireType 2 =*/26).string(message.description);
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                $root.google.protobuf.Timestamp.encode(message.createTime, writer.uint32(/* id 4, wireType 2 =*/34).fork()).ldelim();
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                $root.google.protobuf.Timestamp.encode(message.updateTime, writer.uint32(/* id 5, wireType 2 =*/42).fork()).ldelim();
+                            if (message.perimeterType != null && message.hasOwnProperty("perimeterType"))
+                                writer.uint32(/* id 6, wireType 0 =*/48).int32(message.perimeterType);
+                            if (message.status != null && message.hasOwnProperty("status"))
+                                $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.encode(message.status, writer.uint32(/* id 7, wireType 2 =*/58).fork()).ldelim();
+                            if (message.spec != null && message.hasOwnProperty("spec"))
+                                $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.encode(message.spec, writer.uint32(/* id 8, wireType 2 =*/66).fork()).ldelim();
+                            if (message.useExplicitDryRunSpec != null && message.hasOwnProperty("useExplicitDryRunSpec"))
+                                writer.uint32(/* id 9, wireType 0 =*/72).bool(message.useExplicitDryRunSpec);
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified ServicePerimeter message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeter.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeter} message ServicePerimeter message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        ServicePerimeter.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a ServicePerimeter message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeter} ServicePerimeter
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        ServicePerimeter.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeter();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    message.name = reader.string();
+                                    break;
+                                case 2:
+                                    message.title = reader.string();
+                                    break;
+                                case 3:
+                                    message.description = reader.string();
+                                    break;
+                                case 4:
+                                    message.createTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 5:
+                                    message.updateTime = $root.google.protobuf.Timestamp.decode(reader, reader.uint32());
+                                    break;
+                                case 6:
+                                    message.perimeterType = reader.int32();
+                                    break;
+                                case 7:
+                                    message.status = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.decode(reader, reader.uint32());
+                                    break;
+                                case 8:
+                                    message.spec = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.decode(reader, reader.uint32());
+                                    break;
+                                case 9:
+                                    message.useExplicitDryRunSpec = reader.bool();
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a ServicePerimeter message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeter} ServicePerimeter
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        ServicePerimeter.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a ServicePerimeter message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        ServicePerimeter.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                if (!$util.isString(message.name))
+                                    return "name: string expected";
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                if (!$util.isString(message.title))
+                                    return "title: string expected";
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                if (!$util.isString(message.description))
+                                    return "description: string expected";
+                            if (message.createTime != null && message.hasOwnProperty("createTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.createTime);
+                                if (error)
+                                    return "createTime." + error;
+                            }
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime")) {
+                                var error = $root.google.protobuf.Timestamp.verify(message.updateTime);
+                                if (error)
+                                    return "updateTime." + error;
+                            }
+                            if (message.perimeterType != null && message.hasOwnProperty("perimeterType"))
+                                switch (message.perimeterType) {
+                                default:
+                                    return "perimeterType: enum value expected";
+                                case 0:
+                                case 1:
+                                    break;
+                                }
+                            if (message.status != null && message.hasOwnProperty("status")) {
+                                var error = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify(message.status);
+                                if (error)
+                                    return "status." + error;
+                            }
+                            if (message.spec != null && message.hasOwnProperty("spec")) {
+                                var error = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify(message.spec);
+                                if (error)
+                                    return "spec." + error;
+                            }
+                            if (message.useExplicitDryRunSpec != null && message.hasOwnProperty("useExplicitDryRunSpec"))
+                                if (typeof message.useExplicitDryRunSpec !== "boolean")
+                                    return "useExplicitDryRunSpec: boolean expected";
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a ServicePerimeter message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeter} ServicePerimeter
+                         */
+                        ServicePerimeter.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.ServicePerimeter)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeter();
+                            if (object.name != null)
+                                message.name = String(object.name);
+                            if (object.title != null)
+                                message.title = String(object.title);
+                            if (object.description != null)
+                                message.description = String(object.description);
+                            if (object.createTime != null) {
+                                if (typeof object.createTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeter.createTime: object expected");
+                                message.createTime = $root.google.protobuf.Timestamp.fromObject(object.createTime);
+                            }
+                            if (object.updateTime != null) {
+                                if (typeof object.updateTime !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeter.updateTime: object expected");
+                                message.updateTime = $root.google.protobuf.Timestamp.fromObject(object.updateTime);
+                            }
+                            switch (object.perimeterType) {
+                            case "PERIMETER_TYPE_REGULAR":
+                            case 0:
+                                message.perimeterType = 0;
+                                break;
+                            case "PERIMETER_TYPE_BRIDGE":
+                            case 1:
+                                message.perimeterType = 1;
+                                break;
+                            }
+                            if (object.status != null) {
+                                if (typeof object.status !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeter.status: object expected");
+                                message.status = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.fromObject(object.status);
+                            }
+                            if (object.spec != null) {
+                                if (typeof object.spec !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeter.spec: object expected");
+                                message.spec = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.fromObject(object.spec);
+                            }
+                            if (object.useExplicitDryRunSpec != null)
+                                message.useExplicitDryRunSpec = Boolean(object.useExplicitDryRunSpec);
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a ServicePerimeter message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ServicePerimeter} message ServicePerimeter
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        ServicePerimeter.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.defaults) {
+                                object.name = "";
+                                object.title = "";
+                                object.description = "";
+                                object.createTime = null;
+                                object.updateTime = null;
+                                object.perimeterType = options.enums === String ? "PERIMETER_TYPE_REGULAR" : 0;
+                                object.status = null;
+                                object.spec = null;
+                                object.useExplicitDryRunSpec = false;
+                            }
+                            if (message.name != null && message.hasOwnProperty("name"))
+                                object.name = message.name;
+                            if (message.title != null && message.hasOwnProperty("title"))
+                                object.title = message.title;
+                            if (message.description != null && message.hasOwnProperty("description"))
+                                object.description = message.description;
+                            if (message.createTime != null && message.hasOwnProperty("createTime"))
+                                object.createTime = $root.google.protobuf.Timestamp.toObject(message.createTime, options);
+                            if (message.updateTime != null && message.hasOwnProperty("updateTime"))
+                                object.updateTime = $root.google.protobuf.Timestamp.toObject(message.updateTime, options);
+                            if (message.perimeterType != null && message.hasOwnProperty("perimeterType"))
+                                object.perimeterType = options.enums === String ? $root.google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType[message.perimeterType] : message.perimeterType;
+                            if (message.status != null && message.hasOwnProperty("status"))
+                                object.status = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.toObject(message.status, options);
+                            if (message.spec != null && message.hasOwnProperty("spec"))
+                                object.spec = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.toObject(message.spec, options);
+                            if (message.useExplicitDryRunSpec != null && message.hasOwnProperty("useExplicitDryRunSpec"))
+                                object.useExplicitDryRunSpec = message.useExplicitDryRunSpec;
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this ServicePerimeter to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeter
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        ServicePerimeter.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        /**
+                         * PerimeterType enum.
+                         * @name google.identity.accesscontextmanager.v1.ServicePerimeter.PerimeterType
+                         * @enum {string}
+                         * @property {number} PERIMETER_TYPE_REGULAR=0 PERIMETER_TYPE_REGULAR value
+                         * @property {number} PERIMETER_TYPE_BRIDGE=1 PERIMETER_TYPE_BRIDGE value
+                         */
+                        ServicePerimeter.PerimeterType = (function() {
+                            var valuesById = {}, values = Object.create(valuesById);
+                            values[valuesById[0] = "PERIMETER_TYPE_REGULAR"] = 0;
+                            values[valuesById[1] = "PERIMETER_TYPE_BRIDGE"] = 1;
+                            return values;
+                        })();
+    
+                        return ServicePerimeter;
+                    })();
+    
+                    v1.ServicePerimeterConfig = (function() {
+    
+                        /**
+                         * Properties of a ServicePerimeterConfig.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @interface IServicePerimeterConfig
+                         * @property {Array.<string>|null} [resources] ServicePerimeterConfig resources
+                         * @property {Array.<string>|null} [accessLevels] ServicePerimeterConfig accessLevels
+                         * @property {Array.<string>|null} [restrictedServices] ServicePerimeterConfig restrictedServices
+                         * @property {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices|null} [vpcAccessibleServices] ServicePerimeterConfig vpcAccessibleServices
+                         */
+    
+                        /**
+                         * Constructs a new ServicePerimeterConfig.
+                         * @memberof google.identity.accesscontextmanager.v1
+                         * @classdesc Represents a ServicePerimeterConfig.
+                         * @implements IServicePerimeterConfig
+                         * @constructor
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeterConfig=} [properties] Properties to set
+                         */
+                        function ServicePerimeterConfig(properties) {
+                            this.resources = [];
+                            this.accessLevels = [];
+                            this.restrictedServices = [];
+                            if (properties)
+                                for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                    if (properties[keys[i]] != null)
+                                        this[keys[i]] = properties[keys[i]];
+                        }
+    
+                        /**
+                         * ServicePerimeterConfig resources.
+                         * @member {Array.<string>} resources
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @instance
+                         */
+                        ServicePerimeterConfig.prototype.resources = $util.emptyArray;
+    
+                        /**
+                         * ServicePerimeterConfig accessLevels.
+                         * @member {Array.<string>} accessLevels
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @instance
+                         */
+                        ServicePerimeterConfig.prototype.accessLevels = $util.emptyArray;
+    
+                        /**
+                         * ServicePerimeterConfig restrictedServices.
+                         * @member {Array.<string>} restrictedServices
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @instance
+                         */
+                        ServicePerimeterConfig.prototype.restrictedServices = $util.emptyArray;
+    
+                        /**
+                         * ServicePerimeterConfig vpcAccessibleServices.
+                         * @member {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices|null|undefined} vpcAccessibleServices
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @instance
+                         */
+                        ServicePerimeterConfig.prototype.vpcAccessibleServices = null;
+    
+                        /**
+                         * Creates a new ServicePerimeterConfig instance using the specified properties.
+                         * @function create
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeterConfig=} [properties] Properties to set
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig} ServicePerimeterConfig instance
+                         */
+                        ServicePerimeterConfig.create = function create(properties) {
+                            return new ServicePerimeterConfig(properties);
+                        };
+    
+                        /**
+                         * Encodes the specified ServicePerimeterConfig message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify|verify} messages.
+                         * @function encode
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeterConfig} message ServicePerimeterConfig message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        ServicePerimeterConfig.encode = function encode(message, writer) {
+                            if (!writer)
+                                writer = $Writer.create();
+                            if (message.resources != null && message.resources.length)
+                                for (var i = 0; i < message.resources.length; ++i)
+                                    writer.uint32(/* id 1, wireType 2 =*/10).string(message.resources[i]);
+                            if (message.accessLevels != null && message.accessLevels.length)
+                                for (var i = 0; i < message.accessLevels.length; ++i)
+                                    writer.uint32(/* id 2, wireType 2 =*/18).string(message.accessLevels[i]);
+                            if (message.restrictedServices != null && message.restrictedServices.length)
+                                for (var i = 0; i < message.restrictedServices.length; ++i)
+                                    writer.uint32(/* id 4, wireType 2 =*/34).string(message.restrictedServices[i]);
+                            if (message.vpcAccessibleServices != null && message.hasOwnProperty("vpcAccessibleServices"))
+                                $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.encode(message.vpcAccessibleServices, writer.uint32(/* id 10, wireType 2 =*/82).fork()).ldelim();
+                            return writer;
+                        };
+    
+                        /**
+                         * Encodes the specified ServicePerimeterConfig message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.verify|verify} messages.
+                         * @function encodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.IServicePerimeterConfig} message ServicePerimeterConfig message or plain object to encode
+                         * @param {$protobuf.Writer} [writer] Writer to encode to
+                         * @returns {$protobuf.Writer} Writer
+                         */
+                        ServicePerimeterConfig.encodeDelimited = function encodeDelimited(message, writer) {
+                            return this.encode(message, writer).ldelim();
+                        };
+    
+                        /**
+                         * Decodes a ServicePerimeterConfig message from the specified reader or buffer.
+                         * @function decode
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @param {number} [length] Message length if known beforehand
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig} ServicePerimeterConfig
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        ServicePerimeterConfig.decode = function decode(reader, length) {
+                            if (!(reader instanceof $Reader))
+                                reader = $Reader.create(reader);
+                            var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig();
+                            while (reader.pos < end) {
+                                var tag = reader.uint32();
+                                switch (tag >>> 3) {
+                                case 1:
+                                    if (!(message.resources && message.resources.length))
+                                        message.resources = [];
+                                    message.resources.push(reader.string());
+                                    break;
+                                case 2:
+                                    if (!(message.accessLevels && message.accessLevels.length))
+                                        message.accessLevels = [];
+                                    message.accessLevels.push(reader.string());
+                                    break;
+                                case 4:
+                                    if (!(message.restrictedServices && message.restrictedServices.length))
+                                        message.restrictedServices = [];
+                                    message.restrictedServices.push(reader.string());
+                                    break;
+                                case 10:
+                                    message.vpcAccessibleServices = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.decode(reader, reader.uint32());
+                                    break;
+                                default:
+                                    reader.skipType(tag & 7);
+                                    break;
+                                }
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Decodes a ServicePerimeterConfig message from the specified reader or buffer, length delimited.
+                         * @function decodeDelimited
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig} ServicePerimeterConfig
+                         * @throws {Error} If the payload is not a reader or valid buffer
+                         * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                         */
+                        ServicePerimeterConfig.decodeDelimited = function decodeDelimited(reader) {
+                            if (!(reader instanceof $Reader))
+                                reader = new $Reader(reader);
+                            return this.decode(reader, reader.uint32());
+                        };
+    
+                        /**
+                         * Verifies a ServicePerimeterConfig message.
+                         * @function verify
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {Object.<string,*>} message Plain object to verify
+                         * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                         */
+                        ServicePerimeterConfig.verify = function verify(message) {
+                            if (typeof message !== "object" || message === null)
+                                return "object expected";
+                            if (message.resources != null && message.hasOwnProperty("resources")) {
+                                if (!Array.isArray(message.resources))
+                                    return "resources: array expected";
+                                for (var i = 0; i < message.resources.length; ++i)
+                                    if (!$util.isString(message.resources[i]))
+                                        return "resources: string[] expected";
+                            }
+                            if (message.accessLevels != null && message.hasOwnProperty("accessLevels")) {
+                                if (!Array.isArray(message.accessLevels))
+                                    return "accessLevels: array expected";
+                                for (var i = 0; i < message.accessLevels.length; ++i)
+                                    if (!$util.isString(message.accessLevels[i]))
+                                        return "accessLevels: string[] expected";
+                            }
+                            if (message.restrictedServices != null && message.hasOwnProperty("restrictedServices")) {
+                                if (!Array.isArray(message.restrictedServices))
+                                    return "restrictedServices: array expected";
+                                for (var i = 0; i < message.restrictedServices.length; ++i)
+                                    if (!$util.isString(message.restrictedServices[i]))
+                                        return "restrictedServices: string[] expected";
+                            }
+                            if (message.vpcAccessibleServices != null && message.hasOwnProperty("vpcAccessibleServices")) {
+                                var error = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.verify(message.vpcAccessibleServices);
+                                if (error)
+                                    return "vpcAccessibleServices." + error;
+                            }
+                            return null;
+                        };
+    
+                        /**
+                         * Creates a ServicePerimeterConfig message from a plain object. Also converts values to their respective internal types.
+                         * @function fromObject
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {Object.<string,*>} object Plain object
+                         * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig} ServicePerimeterConfig
+                         */
+                        ServicePerimeterConfig.fromObject = function fromObject(object) {
+                            if (object instanceof $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig)
+                                return object;
+                            var message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig();
+                            if (object.resources) {
+                                if (!Array.isArray(object.resources))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.resources: array expected");
+                                message.resources = [];
+                                for (var i = 0; i < object.resources.length; ++i)
+                                    message.resources[i] = String(object.resources[i]);
+                            }
+                            if (object.accessLevels) {
+                                if (!Array.isArray(object.accessLevels))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.accessLevels: array expected");
+                                message.accessLevels = [];
+                                for (var i = 0; i < object.accessLevels.length; ++i)
+                                    message.accessLevels[i] = String(object.accessLevels[i]);
+                            }
+                            if (object.restrictedServices) {
+                                if (!Array.isArray(object.restrictedServices))
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.restrictedServices: array expected");
+                                message.restrictedServices = [];
+                                for (var i = 0; i < object.restrictedServices.length; ++i)
+                                    message.restrictedServices[i] = String(object.restrictedServices[i]);
+                            }
+                            if (object.vpcAccessibleServices != null) {
+                                if (typeof object.vpcAccessibleServices !== "object")
+                                    throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.vpcAccessibleServices: object expected");
+                                message.vpcAccessibleServices = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.fromObject(object.vpcAccessibleServices);
+                            }
+                            return message;
+                        };
+    
+                        /**
+                         * Creates a plain object from a ServicePerimeterConfig message. Also converts values to other types if specified.
+                         * @function toObject
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @static
+                         * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig} message ServicePerimeterConfig
+                         * @param {$protobuf.IConversionOptions} [options] Conversion options
+                         * @returns {Object.<string,*>} Plain object
+                         */
+                        ServicePerimeterConfig.toObject = function toObject(message, options) {
+                            if (!options)
+                                options = {};
+                            var object = {};
+                            if (options.arrays || options.defaults) {
+                                object.resources = [];
+                                object.accessLevels = [];
+                                object.restrictedServices = [];
+                            }
+                            if (options.defaults)
+                                object.vpcAccessibleServices = null;
+                            if (message.resources && message.resources.length) {
+                                object.resources = [];
+                                for (var j = 0; j < message.resources.length; ++j)
+                                    object.resources[j] = message.resources[j];
+                            }
+                            if (message.accessLevels && message.accessLevels.length) {
+                                object.accessLevels = [];
+                                for (var j = 0; j < message.accessLevels.length; ++j)
+                                    object.accessLevels[j] = message.accessLevels[j];
+                            }
+                            if (message.restrictedServices && message.restrictedServices.length) {
+                                object.restrictedServices = [];
+                                for (var j = 0; j < message.restrictedServices.length; ++j)
+                                    object.restrictedServices[j] = message.restrictedServices[j];
+                            }
+                            if (message.vpcAccessibleServices != null && message.hasOwnProperty("vpcAccessibleServices"))
+                                object.vpcAccessibleServices = $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.toObject(message.vpcAccessibleServices, options);
+                            return object;
+                        };
+    
+                        /**
+                         * Converts this ServicePerimeterConfig to JSON.
+                         * @function toJSON
+                         * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                         * @instance
+                         * @returns {Object.<string,*>} JSON object
+                         */
+                        ServicePerimeterConfig.prototype.toJSON = function toJSON() {
+                            return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                        };
+    
+                        ServicePerimeterConfig.VpcAccessibleServices = (function() {
+    
+                            /**
+                             * Properties of a VpcAccessibleServices.
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                             * @interface IVpcAccessibleServices
+                             * @property {boolean|null} [enableRestriction] VpcAccessibleServices enableRestriction
+                             * @property {Array.<string>|null} [allowedServices] VpcAccessibleServices allowedServices
+                             */
+    
+                            /**
+                             * Constructs a new VpcAccessibleServices.
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig
+                             * @classdesc Represents a VpcAccessibleServices.
+                             * @implements IVpcAccessibleServices
+                             * @constructor
+                             * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices=} [properties] Properties to set
+                             */
+                            function VpcAccessibleServices(properties) {
+                                this.allowedServices = [];
+                                if (properties)
+                                    for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
+                                        if (properties[keys[i]] != null)
+                                            this[keys[i]] = properties[keys[i]];
+                            }
+    
+                            /**
+                             * VpcAccessibleServices enableRestriction.
+                             * @member {boolean} enableRestriction
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @instance
+                             */
+                            VpcAccessibleServices.prototype.enableRestriction = false;
+    
+                            /**
+                             * VpcAccessibleServices allowedServices.
+                             * @member {Array.<string>} allowedServices
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @instance
+                             */
+                            VpcAccessibleServices.prototype.allowedServices = $util.emptyArray;
+    
+                            /**
+                             * Creates a new VpcAccessibleServices instance using the specified properties.
+                             * @function create
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices=} [properties] Properties to set
+                             * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices} VpcAccessibleServices instance
+                             */
+                            VpcAccessibleServices.create = function create(properties) {
+                                return new VpcAccessibleServices(properties);
+                            };
+    
+                            /**
+                             * Encodes the specified VpcAccessibleServices message. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.verify|verify} messages.
+                             * @function encode
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices} message VpcAccessibleServices message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            VpcAccessibleServices.encode = function encode(message, writer) {
+                                if (!writer)
+                                    writer = $Writer.create();
+                                if (message.enableRestriction != null && message.hasOwnProperty("enableRestriction"))
+                                    writer.uint32(/* id 1, wireType 0 =*/8).bool(message.enableRestriction);
+                                if (message.allowedServices != null && message.allowedServices.length)
+                                    for (var i = 0; i < message.allowedServices.length; ++i)
+                                        writer.uint32(/* id 2, wireType 2 =*/18).string(message.allowedServices[i]);
+                                return writer;
+                            };
+    
+                            /**
+                             * Encodes the specified VpcAccessibleServices message, length delimited. Does not implicitly {@link google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.verify|verify} messages.
+                             * @function encodeDelimited
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.IVpcAccessibleServices} message VpcAccessibleServices message or plain object to encode
+                             * @param {$protobuf.Writer} [writer] Writer to encode to
+                             * @returns {$protobuf.Writer} Writer
+                             */
+                            VpcAccessibleServices.encodeDelimited = function encodeDelimited(message, writer) {
+                                return this.encode(message, writer).ldelim();
+                            };
+    
+                            /**
+                             * Decodes a VpcAccessibleServices message from the specified reader or buffer.
+                             * @function decode
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @param {number} [length] Message length if known beforehand
+                             * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices} VpcAccessibleServices
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            VpcAccessibleServices.decode = function decode(reader, length) {
+                                if (!(reader instanceof $Reader))
+                                    reader = $Reader.create(reader);
+                                var end = length === undefined ? reader.len : reader.pos + length, message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices();
+                                while (reader.pos < end) {
+                                    var tag = reader.uint32();
+                                    switch (tag >>> 3) {
+                                    case 1:
+                                        message.enableRestriction = reader.bool();
+                                        break;
+                                    case 2:
+                                        if (!(message.allowedServices && message.allowedServices.length))
+                                            message.allowedServices = [];
+                                        message.allowedServices.push(reader.string());
+                                        break;
+                                    default:
+                                        reader.skipType(tag & 7);
+                                        break;
+                                    }
+                                }
+                                return message;
+                            };
+    
+                            /**
+                             * Decodes a VpcAccessibleServices message from the specified reader or buffer, length delimited.
+                             * @function decodeDelimited
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {$protobuf.Reader|Uint8Array} reader Reader or buffer to decode from
+                             * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices} VpcAccessibleServices
+                             * @throws {Error} If the payload is not a reader or valid buffer
+                             * @throws {$protobuf.util.ProtocolError} If required fields are missing
+                             */
+                            VpcAccessibleServices.decodeDelimited = function decodeDelimited(reader) {
+                                if (!(reader instanceof $Reader))
+                                    reader = new $Reader(reader);
+                                return this.decode(reader, reader.uint32());
+                            };
+    
+                            /**
+                             * Verifies a VpcAccessibleServices message.
+                             * @function verify
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {Object.<string,*>} message Plain object to verify
+                             * @returns {string|null} `null` if valid, otherwise the reason why it is not
+                             */
+                            VpcAccessibleServices.verify = function verify(message) {
+                                if (typeof message !== "object" || message === null)
+                                    return "object expected";
+                                if (message.enableRestriction != null && message.hasOwnProperty("enableRestriction"))
+                                    if (typeof message.enableRestriction !== "boolean")
+                                        return "enableRestriction: boolean expected";
+                                if (message.allowedServices != null && message.hasOwnProperty("allowedServices")) {
+                                    if (!Array.isArray(message.allowedServices))
+                                        return "allowedServices: array expected";
+                                    for (var i = 0; i < message.allowedServices.length; ++i)
+                                        if (!$util.isString(message.allowedServices[i]))
+                                            return "allowedServices: string[] expected";
+                                }
+                                return null;
+                            };
+    
+                            /**
+                             * Creates a VpcAccessibleServices message from a plain object. Also converts values to their respective internal types.
+                             * @function fromObject
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {Object.<string,*>} object Plain object
+                             * @returns {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices} VpcAccessibleServices
+                             */
+                            VpcAccessibleServices.fromObject = function fromObject(object) {
+                                if (object instanceof $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices)
+                                    return object;
+                                var message = new $root.google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices();
+                                if (object.enableRestriction != null)
+                                    message.enableRestriction = Boolean(object.enableRestriction);
+                                if (object.allowedServices) {
+                                    if (!Array.isArray(object.allowedServices))
+                                        throw TypeError(".google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices.allowedServices: array expected");
+                                    message.allowedServices = [];
+                                    for (var i = 0; i < object.allowedServices.length; ++i)
+                                        message.allowedServices[i] = String(object.allowedServices[i]);
+                                }
+                                return message;
+                            };
+    
+                            /**
+                             * Creates a plain object from a VpcAccessibleServices message. Also converts values to other types if specified.
+                             * @function toObject
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @static
+                             * @param {google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices} message VpcAccessibleServices
+                             * @param {$protobuf.IConversionOptions} [options] Conversion options
+                             * @returns {Object.<string,*>} Plain object
+                             */
+                            VpcAccessibleServices.toObject = function toObject(message, options) {
+                                if (!options)
+                                    options = {};
+                                var object = {};
+                                if (options.arrays || options.defaults)
+                                    object.allowedServices = [];
+                                if (options.defaults)
+                                    object.enableRestriction = false;
+                                if (message.enableRestriction != null && message.hasOwnProperty("enableRestriction"))
+                                    object.enableRestriction = message.enableRestriction;
+                                if (message.allowedServices && message.allowedServices.length) {
+                                    object.allowedServices = [];
+                                    for (var j = 0; j < message.allowedServices.length; ++j)
+                                        object.allowedServices[j] = message.allowedServices[j];
+                                }
+                                return object;
+                            };
+    
+                            /**
+                             * Converts this VpcAccessibleServices to JSON.
+                             * @function toJSON
+                             * @memberof google.identity.accesscontextmanager.v1.ServicePerimeterConfig.VpcAccessibleServices
+                             * @instance
+                             * @returns {Object.<string,*>} JSON object
+                             */
+                            VpcAccessibleServices.prototype.toJSON = function toJSON() {
+                                return this.constructor.toObject(this, $protobuf.util.toJSONOptions);
+                            };
+    
+                            return VpcAccessibleServices;
+                        })();
+    
+                        return ServicePerimeterConfig;
+                    })();
+    
+                    return v1;
+                })();
+    
+                accesscontextmanager.type = (function() {
+    
+                    /**
+                     * Namespace type.
+                     * @memberof google.identity.accesscontextmanager
+                     * @namespace
+                     */
+                    var type = {};
+    
+                    /**
+                     * DeviceEncryptionStatus enum.
+                     * @name google.identity.accesscontextmanager.type.DeviceEncryptionStatus
+                     * @enum {string}
+                     * @property {number} ENCRYPTION_UNSPECIFIED=0 ENCRYPTION_UNSPECIFIED value
+                     * @property {number} ENCRYPTION_UNSUPPORTED=1 ENCRYPTION_UNSUPPORTED value
+                     * @property {number} UNENCRYPTED=2 UNENCRYPTED value
+                     * @property {number} ENCRYPTED=3 ENCRYPTED value
+                     */
+                    type.DeviceEncryptionStatus = (function() {
+                        var valuesById = {}, values = Object.create(valuesById);
+                        values[valuesById[0] = "ENCRYPTION_UNSPECIFIED"] = 0;
+                        values[valuesById[1] = "ENCRYPTION_UNSUPPORTED"] = 1;
+                        values[valuesById[2] = "UNENCRYPTED"] = 2;
+                        values[valuesById[3] = "ENCRYPTED"] = 3;
+                        return values;
+                    })();
+    
+                    /**
+                     * OsType enum.
+                     * @name google.identity.accesscontextmanager.type.OsType
+                     * @enum {string}
+                     * @property {number} OS_UNSPECIFIED=0 OS_UNSPECIFIED value
+                     * @property {number} DESKTOP_MAC=1 DESKTOP_MAC value
+                     * @property {number} DESKTOP_WINDOWS=2 DESKTOP_WINDOWS value
+                     * @property {number} DESKTOP_LINUX=3 DESKTOP_LINUX value
+                     * @property {number} DESKTOP_CHROME_OS=6 DESKTOP_CHROME_OS value
+                     * @property {number} ANDROID=4 ANDROID value
+                     * @property {number} IOS=5 IOS value
+                     */
+                    type.OsType = (function() {
+                        var valuesById = {}, values = Object.create(valuesById);
+                        values[valuesById[0] = "OS_UNSPECIFIED"] = 0;
+                        values[valuesById[1] = "DESKTOP_MAC"] = 1;
+                        values[valuesById[2] = "DESKTOP_WINDOWS"] = 2;
+                        values[valuesById[3] = "DESKTOP_LINUX"] = 3;
+                        values[valuesById[6] = "DESKTOP_CHROME_OS"] = 6;
+                        values[valuesById[4] = "ANDROID"] = 4;
+                        values[valuesById[5] = "IOS"] = 5;
+                        return values;
+                    })();
+    
+                    /**
+                     * DeviceManagementLevel enum.
+                     * @name google.identity.accesscontextmanager.type.DeviceManagementLevel
+                     * @enum {string}
+                     * @property {number} MANAGEMENT_UNSPECIFIED=0 MANAGEMENT_UNSPECIFIED value
+                     * @property {number} NONE=1 NONE value
+                     * @property {number} BASIC=2 BASIC value
+                     * @property {number} COMPLETE=3 COMPLETE value
+                     */
+                    type.DeviceManagementLevel = (function() {
+                        var valuesById = {}, values = Object.create(valuesById);
+                        values[valuesById[0] = "MANAGEMENT_UNSPECIFIED"] = 0;
+                        values[valuesById[1] = "NONE"] = 1;
+                        values[valuesById[2] = "BASIC"] = 2;
+                        values[valuesById[3] = "COMPLETE"] = 3;
+                        return values;
+                    })();
+    
+                    return type;
+                })();
+    
+                return accesscontextmanager;
+            })();
+    
+            return identity;
         })();
     
         google.longrunning = (function() {

--- a/protos/protos.json
+++ b/protos/protos.json
@@ -325,15 +325,6 @@
                         }
                       }
                     },
-                    "ContentType": {
-                      "values": {
-                        "CONTENT_TYPE_UNSPECIFIED": 0,
-                        "RESOURCE": 1,
-                        "IAM_POLICY": 2,
-                        "ORG_POLICY": 4,
-                        "ACCESS_POLICY": 5
-                      }
-                    },
                     "FeedOutputConfig": {
                       "oneofs": {
                         "destination": {
@@ -386,6 +377,15 @@
                         }
                       }
                     },
+                    "ContentType": {
+                      "values": {
+                        "CONTENT_TYPE_UNSPECIFIED": 0,
+                        "RESOURCE": 1,
+                        "IAM_POLICY": 2,
+                        "ORG_POLICY": 4,
+                        "ACCESS_POLICY": 5
+                      }
+                    },
                     "TemporalAsset": {
                       "fields": {
                         "window": {
@@ -419,6 +419,15 @@
                         "(google.api.resource).type": "cloudasset.googleapis.com/Asset",
                         "(google.api.resource).pattern": "*"
                       },
+                      "oneofs": {
+                        "accessContextPolicy": {
+                          "oneof": [
+                            "accessPolicy",
+                            "accessLevel",
+                            "servicePerimeter"
+                          ]
+                        }
+                      },
                       "fields": {
                         "name": {
                           "type": "string",
@@ -435,6 +444,23 @@
                         "iamPolicy": {
                           "type": "google.iam.v1.Policy",
                           "id": 4
+                        },
+                        "orgPolicy": {
+                          "rule": "repeated",
+                          "type": "google.cloud.orgpolicy.v1.Policy",
+                          "id": 6
+                        },
+                        "accessPolicy": {
+                          "type": "google.identity.accesscontextmanager.v1.AccessPolicy",
+                          "id": 7
+                        },
+                        "accessLevel": {
+                          "type": "google.identity.accesscontextmanager.v1.AccessLevel",
+                          "id": 8
+                        },
+                        "servicePerimeter": {
+                          "type": "google.identity.accesscontextmanager.v1.ServicePerimeter",
+                          "id": 9
                         },
                         "ancestors": {
                           "rule": "repeated",
@@ -1698,6 +1724,112 @@
                   }
                 }
               }
+            },
+            "orgpolicy": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "Google.Cloud.OrgPolicy.V1",
+                    "go_package": "google.golang.org/genproto/googleapis/cloud/orgpolicy/v1;orgpolicy",
+                    "java_multiple_files": true,
+                    "java_outer_classname": "OrgPolicyProto",
+                    "java_package": "com.google.cloud.orgpolicy.v1",
+                    "php_namespace": "Google\\Cloud\\OrgPolicy\\V1",
+                    "ruby_package": "Google::Cloud::OrgPolicy::V1"
+                  },
+                  "nested": {
+                    "Policy": {
+                      "oneofs": {
+                        "policyType": {
+                          "oneof": [
+                            "listPolicy",
+                            "booleanPolicy",
+                            "restoreDefault"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "version": {
+                          "type": "int32",
+                          "id": 1
+                        },
+                        "constraint": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "etag": {
+                          "type": "bytes",
+                          "id": 3
+                        },
+                        "updateTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 4
+                        },
+                        "listPolicy": {
+                          "type": "ListPolicy",
+                          "id": 5
+                        },
+                        "booleanPolicy": {
+                          "type": "BooleanPolicy",
+                          "id": 6
+                        },
+                        "restoreDefault": {
+                          "type": "RestoreDefault",
+                          "id": 7
+                        }
+                      },
+                      "nested": {
+                        "ListPolicy": {
+                          "fields": {
+                            "allowedValues": {
+                              "rule": "repeated",
+                              "type": "string",
+                              "id": 1
+                            },
+                            "deniedValues": {
+                              "rule": "repeated",
+                              "type": "string",
+                              "id": 2
+                            },
+                            "allValues": {
+                              "type": "AllValues",
+                              "id": 3
+                            },
+                            "suggestedValue": {
+                              "type": "string",
+                              "id": 4
+                            },
+                            "inheritFromParent": {
+                              "type": "bool",
+                              "id": 5
+                            }
+                          },
+                          "nested": {
+                            "AllValues": {
+                              "values": {
+                                "ALL_VALUES_UNSPECIFIED": 0,
+                                "ALLOW": 1,
+                                "DENY": 2
+                              }
+                            }
+                          }
+                        },
+                        "BooleanPolicy": {
+                          "fields": {
+                            "enforced": {
+                              "type": "bool",
+                              "id": 1
+                            }
+                          }
+                        },
+                        "RestoreDefault": {
+                          "fields": {}
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
         },
@@ -2789,6 +2921,21 @@
                 }
               }
             },
+            "Empty": {
+              "fields": {}
+            },
+            "Timestamp": {
+              "fields": {
+                "seconds": {
+                  "type": "int64",
+                  "id": 1
+                },
+                "nanos": {
+                  "type": "int32",
+                  "id": 2
+                }
+              }
+            },
             "Any": {
               "fields": {
                 "type_url": {
@@ -2864,18 +3011,6 @@
                 }
               }
             },
-            "Timestamp": {
-              "fields": {
-                "seconds": {
-                  "type": "int64",
-                  "id": 1
-                },
-                "nanos": {
-                  "type": "int32",
-                  "id": 2
-                }
-              }
-            },
             "Duration": {
               "fields": {
                 "seconds": {
@@ -2887,9 +3022,6 @@
                   "id": 2
                 }
               }
-            },
-            "Empty": {
-              "fields": {}
             },
             "FieldMask": {
               "fields": {
@@ -3051,6 +3183,330 @@
                 "location": {
                   "type": "string",
                   "id": 4
+                }
+              }
+            }
+          }
+        },
+        "identity": {
+          "nested": {
+            "accesscontextmanager": {
+              "nested": {
+                "v1": {
+                  "options": {
+                    "csharp_namespace": "Google.Identity.AccessContextManager.V1",
+                    "go_package": "google.golang.org/genproto/googleapis/identity/accesscontextmanager/v1;accesscontextmanager",
+                    "java_multiple_files": true,
+                    "java_outer_classname": "ServicePerimeterProto",
+                    "java_package": "com.google.identity.accesscontextmanager.v1",
+                    "php_namespace": "Google\\Identity\\AccessContextManager\\V1",
+                    "ruby_package": "Google::Identity::AccessContextManager::V1",
+                    "objc_class_prefix": "GACM"
+                  },
+                  "nested": {
+                    "AccessLevel": {
+                      "oneofs": {
+                        "level": {
+                          "oneof": [
+                            "basic",
+                            "custom"
+                          ]
+                        }
+                      },
+                      "fields": {
+                        "name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "title": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "description": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "basic": {
+                          "type": "BasicLevel",
+                          "id": 4
+                        },
+                        "custom": {
+                          "type": "CustomLevel",
+                          "id": 5
+                        },
+                        "createTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 6
+                        },
+                        "updateTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 7
+                        }
+                      }
+                    },
+                    "BasicLevel": {
+                      "fields": {
+                        "conditions": {
+                          "rule": "repeated",
+                          "type": "Condition",
+                          "id": 1
+                        },
+                        "combiningFunction": {
+                          "type": "ConditionCombiningFunction",
+                          "id": 2
+                        }
+                      },
+                      "nested": {
+                        "ConditionCombiningFunction": {
+                          "values": {
+                            "AND": 0,
+                            "OR": 1
+                          }
+                        }
+                      }
+                    },
+                    "Condition": {
+                      "fields": {
+                        "ipSubnetworks": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 1
+                        },
+                        "devicePolicy": {
+                          "type": "DevicePolicy",
+                          "id": 2
+                        },
+                        "requiredAccessLevels": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 3
+                        },
+                        "negate": {
+                          "type": "bool",
+                          "id": 5
+                        },
+                        "members": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 6
+                        },
+                        "regions": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 7
+                        }
+                      }
+                    },
+                    "CustomLevel": {
+                      "fields": {
+                        "expr": {
+                          "type": "google.type.Expr",
+                          "id": 1
+                        }
+                      }
+                    },
+                    "DevicePolicy": {
+                      "fields": {
+                        "requireScreenlock": {
+                          "type": "bool",
+                          "id": 1
+                        },
+                        "allowedEncryptionStatuses": {
+                          "rule": "repeated",
+                          "type": "google.identity.accesscontextmanager.type.DeviceEncryptionStatus",
+                          "id": 2
+                        },
+                        "osConstraints": {
+                          "rule": "repeated",
+                          "type": "OsConstraint",
+                          "id": 3
+                        },
+                        "allowedDeviceManagementLevels": {
+                          "rule": "repeated",
+                          "type": "google.identity.accesscontextmanager.type.DeviceManagementLevel",
+                          "id": 6
+                        },
+                        "requireAdminApproval": {
+                          "type": "bool",
+                          "id": 7
+                        },
+                        "requireCorpOwned": {
+                          "type": "bool",
+                          "id": 8
+                        }
+                      }
+                    },
+                    "OsConstraint": {
+                      "fields": {
+                        "osType": {
+                          "type": "google.identity.accesscontextmanager.type.OsType",
+                          "id": 1
+                        },
+                        "minimumVersion": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "requireVerifiedChromeOs": {
+                          "type": "bool",
+                          "id": 3
+                        }
+                      }
+                    },
+                    "AccessPolicy": {
+                      "fields": {
+                        "name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "parent": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "title": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "createTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 4
+                        },
+                        "updateTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 5
+                        },
+                        "etag": {
+                          "type": "string",
+                          "id": 6
+                        }
+                      }
+                    },
+                    "ServicePerimeter": {
+                      "fields": {
+                        "name": {
+                          "type": "string",
+                          "id": 1
+                        },
+                        "title": {
+                          "type": "string",
+                          "id": 2
+                        },
+                        "description": {
+                          "type": "string",
+                          "id": 3
+                        },
+                        "createTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 4
+                        },
+                        "updateTime": {
+                          "type": "google.protobuf.Timestamp",
+                          "id": 5
+                        },
+                        "perimeterType": {
+                          "type": "PerimeterType",
+                          "id": 6
+                        },
+                        "status": {
+                          "type": "ServicePerimeterConfig",
+                          "id": 7
+                        },
+                        "spec": {
+                          "type": "ServicePerimeterConfig",
+                          "id": 8
+                        },
+                        "useExplicitDryRunSpec": {
+                          "type": "bool",
+                          "id": 9
+                        }
+                      },
+                      "nested": {
+                        "PerimeterType": {
+                          "values": {
+                            "PERIMETER_TYPE_REGULAR": 0,
+                            "PERIMETER_TYPE_BRIDGE": 1
+                          }
+                        }
+                      }
+                    },
+                    "ServicePerimeterConfig": {
+                      "fields": {
+                        "resources": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 1
+                        },
+                        "accessLevels": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 2
+                        },
+                        "restrictedServices": {
+                          "rule": "repeated",
+                          "type": "string",
+                          "id": 4
+                        },
+                        "vpcAccessibleServices": {
+                          "type": "VpcAccessibleServices",
+                          "id": 10
+                        }
+                      },
+                      "nested": {
+                        "VpcAccessibleServices": {
+                          "fields": {
+                            "enableRestriction": {
+                              "type": "bool",
+                              "id": 1
+                            },
+                            "allowedServices": {
+                              "rule": "repeated",
+                              "type": "string",
+                              "id": 2
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "type": {
+                  "options": {
+                    "csharp_namespace": "Google.Identity.AccessContextManager.Type",
+                    "go_package": "google.golang.org/genproto/googleapis/identity/accesscontextmanager/type;type",
+                    "java_package": "com.google.identity.accesscontextmanager.type",
+                    "java_multiple_files": true,
+                    "java_outer_classname": "TypeProto",
+                    "php_namespace": "Google\\Identity\\AccessContextManager\\Type",
+                    "ruby_package": "Google::Identity::AccessContextManager::Type"
+                  },
+                  "nested": {
+                    "DeviceEncryptionStatus": {
+                      "values": {
+                        "ENCRYPTION_UNSPECIFIED": 0,
+                        "ENCRYPTION_UNSUPPORTED": 1,
+                        "UNENCRYPTED": 2,
+                        "ENCRYPTED": 3
+                      }
+                    },
+                    "OsType": {
+                      "values": {
+                        "OS_UNSPECIFIED": 0,
+                        "DESKTOP_MAC": 1,
+                        "DESKTOP_WINDOWS": 2,
+                        "DESKTOP_LINUX": 3,
+                        "DESKTOP_CHROME_OS": 6,
+                        "ANDROID": 4,
+                        "IOS": 5
+                      }
+                    },
+                    "DeviceManagementLevel": {
+                      "values": {
+                        "MANAGEMENT_UNSPECIFIED": 0,
+                        "NONE": 1,
+                        "BASIC": 2,
+                        "COMPLETE": 3
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/src/v1/asset_service_client.ts
+++ b/src/v1/asset_service_client.ts
@@ -18,7 +18,6 @@
 
 import * as gax from 'google-gax';
 import {
-  GaxCall,
   Callback,
   CallOptions,
   Descriptors,
@@ -390,11 +389,11 @@ export class AssetServiceClient {
    *   Optional. The content type.
    * @param {google.cloud.asset.v1.TimeWindow} [request.readTimeWindow]
    *   Optional. The time window for the asset history. Both start_time and
-   *   end_time are optional and if set, it must be after 2018-10-02 UTC. If
-   *   end_time is not set, it is default to current timestamp. If start_time is
-   *   not set, the snapshot of the assets at end_time will be returned. The
-   *   returned results contain all temporal assets whose time window overlap with
-   *   read_time_window.
+   *   end_time are optional and if set, it must be after the current time minus
+   *   35 days. If end_time is not set, it is default to current timestamp.
+   *   If start_time is not set, the snapshot of the assets at end_time will be
+   *   returned. The returned results contain all temporal assets whose time
+   *   window overlap with read_time_window.
    * @param {object} [options]
    *   Call options. See {@link https://googleapis.dev/nodejs/google-gax/latest/interfaces/CallOptions.html|CallOptions} for more details.
    * @returns {Promise} - The promise which resolves to an array.
@@ -927,10 +926,10 @@ export class AssetServiceClient {
    *   or a folder number (such as "folders/123").
    * @param {google.protobuf.Timestamp} request.readTime
    *   Timestamp to take an asset snapshot. This can only be set to a timestamp
-   *   between 2018-10-02 UTC (inclusive) and the current time. If not specified,
-   *   the current time will be used. Due to delays in resource data collection
-   *   and indexing, there is a volatile window during which running the same
-   *   query may get different results.
+   *   between the current time and the current time minus 35 days (inclusive).
+   *   If not specified, the current time will be used. Due to delays in resource
+   *   data collection and indexing, there is a volatile window during which
+   *   running the same query may get different results.
    * @param {string[]} request.assetTypes
    *   A list of asset types of which to take a snapshot for. For example:
    *   "compute.googleapis.com/Disk". If specified, only matching assets will be

--- a/src/v1/asset_service_client_config.json
+++ b/src/v1/asset_service_client_config.json
@@ -21,13 +21,11 @@
       },
       "methods": {
         "ExportAssets": {
-          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "BatchGetAssetsHistory": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateFeed": {

--- a/src/v1/asset_service_proto_list.json
+++ b/src/v1/asset_service_proto_list.json
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1/assets.proto"
+  "../../protos/google/cloud/asset/v1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/src/v1beta1/asset_service_client.ts
+++ b/src/v1beta1/asset_service_client.ts
@@ -18,7 +18,6 @@
 
 import * as gax from 'google-gax';
 import {
-  GaxCall,
   Callback,
   CallOptions,
   Descriptors,

--- a/src/v1beta1/asset_service_client_config.json
+++ b/src/v1beta1/asset_service_client_config.json
@@ -21,13 +21,11 @@
       },
       "methods": {
         "ExportAssets": {
-          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "BatchGetAssetsHistory": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/v1beta1/asset_service_proto_list.json
+++ b/src/v1beta1/asset_service_proto_list.json
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1beta1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1beta1/assets.proto"
+  "../../protos/google/cloud/asset/v1beta1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/src/v1p1beta1/asset_service_client.ts
+++ b/src/v1p1beta1/asset_service_client.ts
@@ -18,12 +18,12 @@
 
 import * as gax from 'google-gax';
 import {
-  GaxCall,
   Callback,
   CallOptions,
   Descriptors,
   ClientOptions,
   PaginationCallback,
+  GaxCall,
 } from 'google-gax';
 import * as path from 'path';
 

--- a/src/v1p1beta1/asset_service_client_config.json
+++ b/src/v1p1beta1/asset_service_client_config.json
@@ -21,13 +21,11 @@
       },
       "methods": {
         "SearchAllResources": {
-          "timeout_millis": 15000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "SearchAllIamPolicies": {
-          "timeout_millis": 15000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/v1p1beta1/asset_service_proto_list.json
+++ b/src/v1p1beta1/asset_service_proto_list.json
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1p1beta1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1p1beta1/assets.proto"
+  "../../protos/google/cloud/asset/v1p1beta1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/src/v1p2beta1/asset_service_client.ts
+++ b/src/v1p2beta1/asset_service_client.ts
@@ -17,13 +17,7 @@
 // ** All changes to this file may be overwritten. **
 
 import * as gax from 'google-gax';
-import {
-  GaxCall,
-  Callback,
-  CallOptions,
-  Descriptors,
-  ClientOptions,
-} from 'google-gax';
+import {Callback, CallOptions, Descriptors, ClientOptions} from 'google-gax';
 import * as path from 'path';
 
 import * as protos from '../../protos/protos';

--- a/src/v1p2beta1/asset_service_client_config.json
+++ b/src/v1p2beta1/asset_service_client_config.json
@@ -21,28 +21,23 @@
       },
       "methods": {
         "CreateFeed": {
-          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetFeed": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListFeeds": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "UpdateFeed": {
-          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "DeleteFeed": {
-          "timeout_millis": 60000,
-          "retry_codes_name": "idempotent",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }
       }

--- a/src/v1p2beta1/asset_service_proto_list.json
+++ b/src/v1p2beta1/asset_service_proto_list.json
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1p2beta1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1p2beta1/assets.proto"
+  "../../protos/google/cloud/asset/v1p2beta1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/src/v1p4beta1/asset_service_client.ts
+++ b/src/v1p4beta1/asset_service_client.ts
@@ -18,7 +18,6 @@
 
 import * as gax from 'google-gax';
 import {
-  GaxCall,
   Callback,
   CallOptions,
   Descriptors,

--- a/src/v1p4beta1/asset_service_client_config.json
+++ b/src/v1p4beta1/asset_service_client_config.json
@@ -6,9 +6,6 @@
         "idempotent": [
           "DEADLINE_EXCEEDED",
           "UNAVAILABLE"
-        ],
-        "unavailable": [
-          "UNAVAILABLE"
         ]
       },
       "retry_params": {
@@ -24,12 +21,10 @@
       },
       "methods": {
         "AnalyzeIamPolicy": {
-          "timeout_millis": 300000,
-          "retry_codes_name": "unavailable",
+          "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ExportIamPolicyAnalysis": {
-          "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         }

--- a/src/v1p4beta1/asset_service_proto_list.json
+++ b/src/v1p4beta1/asset_service_proto_list.json
@@ -1,4 +1,9 @@
 [
   "../../protos/google/cloud/asset/v1p4beta1/asset_service.proto",
-  "../../protos/google/cloud/asset/v1p4beta1/assets.proto"
+  "../../protos/google/cloud/asset/v1p4beta1/assets.proto",
+  "../../protos/google/cloud/orgpolicy/v1/orgpolicy.proto",
+  "../../protos/google/identity/accesscontextmanager/type/device_resources.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_level.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/access_policy.proto",
+  "../../protos/google/identity/accesscontextmanager/v1/service_perimeter.proto"
 ]

--- a/synth.metadata
+++ b/synth.metadata
@@ -1,5 +1,22 @@
 {
-  "updateTime": "2020-03-31T10:43:55.667140Z",
+  "updateTime": "2020-04-03T20:09:36.093848Z",
+  "sources": [
+    {
+      "git": {
+        "name": "googleapis",
+        "remote": "https://github.com/googleapis/googleapis.git",
+        "sha": "0f7b1509a9a452808c3d07fe90fedfcea763d7d5",
+        "internalRef": "304672648"
+      }
+    },
+    {
+      "git": {
+        "name": "synthtool",
+        "remote": "https://github.com/googleapis/synthtool.git",
+        "sha": "99820243d348191bc9c634f2b48ddf65096285ed"
+      }
+    }
+  ],
   "destinations": [
     {
       "client": {

--- a/synth.py
+++ b/synth.py
@@ -35,6 +35,8 @@ for version in versions:
             'grpc-service-config': f'google/cloud/{name}/{version}/cloud{name}_grpc_service_config.json',
             'package-name': f'@google-cloud/{name}'
         },
+        # This API has dependencies outside of its own folder so we list them here.
+        # Switching to bazel build should help get rid of this.
         extra_proto_files=['google/cloud/common_resources.proto', 'google/cloud/orgpolicy/v1', 'google/identity/accesscontextmanager'],
         version=version),
     # skip index, protos, package.json, and README.md
@@ -48,6 +50,10 @@ common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(source_location='build/src')
 s.copy(templates)
 
+# Extra proto dependencies make the *_proto_list.json have some common files
+# that conflict with the same common files imported from gax. This is likely
+# a generator problem that needs to be fixed when we start handling synth.py
+# custom fixes.
 proto_lists=[f'src/{version}/asset_service_proto_list.json' for version in versions]
 remove_proto_keywords=['/google/api', '/google/protobuf', '/google/rpc', '/google/type']
 for file in proto_lists:

--- a/system-test/fixtures/sample/src/index.ts
+++ b/system-test/fixtures/sample/src/index.ts
@@ -19,7 +19,7 @@
 import {AssetServiceClient} from '@google-cloud/asset';
 
 function main() {
-  const assetServiceClient = new AssetServiceClient();
+  new AssetServiceClient();
 }
 
 main();


### PR DESCRIPTION
Fixes #303. Regenerates the library that now has a lot of external dependencies, so we now have more `extra_proto_files` in `synth.py`:

```
   extra_proto_files=['google/cloud/common_resources.proto', 'google/cloud/orgpolicy/v1', 'google/identity/accesscontextmanager'],
```

(and a few more hacks to make this work).