### PR TITLE
fix: in rare cases test can take longer than 180,000 timeout

### DIFF
--- a/samples/exportAssets.js
+++ b/samples/exportAssets.js
@@ -49,7 +49,9 @@ async function main(dumpFilePath) {
     // Do things with with the response.
     console.log(result);
   }
-  exportAssets();
+  exportAssets().catch((err) => {
+    throw err;
+  });
   // [END asset_quickstart_export_assets]
 }
 


### PR DESCRIPTION
I've noticed in the past that there's a bit of variation in `exportAssets`, rather than extending the timeout on tests further, let's use the retry approach we've been starting to land on for some integration tests.