### PR TITLE
fix: flaky test

### DIFF
--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -49,7 +49,7 @@ async function main(assetNames) {
     console.log(util.inspect(result, {depth: null}));
     // [END asset_quickstart]
   }
-  quickstart();
+  await quickstart();
 }
 
 main(...process.argv.slice(2));


### PR DESCRIPTION
Not really sure why the test is flaky.  Maybe without the await
statement, the process exist before the console is written to.

Fixes #565
